### PR TITLE
Implot v0.9 binding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "imgui-cpp"]
 	path = imgui-cpp
 	url = https://github.com/ocornut/imgui.git
+
+[submodule "implot-cpp"]
+	path = implot-cpp
+	url = https://github.com/epezent/implot.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,5 +15,8 @@ recursive-include imgui-cpp *.cpp *.h
 prune imgui-cpp/examples
 prune imgui-cpp/extra_fonts
 
+# ImPlot sources
+recursive-include implot-cpp *.cpp *.h
+
 # ansifeed sources
 recursive-include ansifeed-cpp *.cpp *.h

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![completion](https://img.shields.io/badge/completion-81%25%20%28373%20of%20458%29-blue.svg)](https://github.com/swistakm/pyimgui)
+[![completion](https://img.shields.io/badge/completion-70%25%20%28518%20of%20735%29-blue.svg)](https://github.com/swistakm/pyimgui)
 [![Coverage Status](https://coveralls.io/repos/github/swistakm/pyimgui/badge.svg?branch=master)](https://coveralls.io/github/swistakm/pyimgui?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/pyimgui/badge/?version=latest)](https://pyimgui.readthedocs.io/en/latest/?badge=latest)
 
@@ -16,10 +16,65 @@ Immediate Mode Graphical User Interface.
 
 Documentation: [pyimgui.readthedocs.io](https://pyimgui.readthedocs.io/en/latest/index.html)
 
+# ImPlot
+
+This fork includes python bindings for the amazing
+[ImPlot](https://github.com/ocornut/imgui), GPU accelerated plotting library for
+[Dear ImGui](https://github.com/ocornut/imgui).
+
+
+        Warning: This is alpha quality code.
+
+Have a look at the `doc/examples/integrations_glfw3_implot.py` that includes ImPlot
+demo. Note that the demo was **NOT** ported to python yet.
+
+It is not clear to me if this is the best place for ImPlot python binding. The
+question remains if it would be better to place this code into a separate project,
+or provide it as part of pyimgui. As of now the latter has been chosen due to my
+laziness, poor undestanding of cython and also due to some obstacles
+encountered during the process of creating this binding.
+
+Read on if you are interested in couple of details.
+
+As per ImGui and ImPlot documentation using them both as shared library is not recomended.
+In case of python binding this is exactly what is being done. The ImGui part ends up being
+a shared library and plot becomes a separate shared library. Creating a single shared library
+(with ImGui and ImPlot) does not sound like a good idea at all so lets not go there. Not going
+with shared library is also something that we can not do; AFAICT due to the way cypthon does
+its business (I might be wrong).
+
+At the level of C++ that cython wraps into python module and functions, ImPlot want access
+to `imgui.h` and `imgui_internal.h`. For example ImPlot uses `ImTextureID`, `ImGuiCond`,
+`ImGuiMouseButton`, `ImGuiKeyModFlags`, `ImGuiDragDropFlags`, `ImU32`, `ImDrawList`, `ImGuiContext`,
+`ImVec2`, `ImVec4` and alike. These need to be exposed a cython level, too. Currently,
+these come from `cimgui` and `internal` modules provided by pyimgui binding. Using them is
+as simple as adding a `cimport` line to a `cimplot.pxd`. pyimgui (c)imports were requiered for
+`plot.pyx` as well:
+
+        cimport cimplot
+        cimport cimgui
+        cimport core
+        cimport enums
+
+If the ImPlot is placed in a separate project/repo these would need to be redefined.
+
+
+When I tried to compile the ImPlot C++ code for cython binding (without adding ImGui sources)
+for that shared library, doing `import imgui` in a user script fails with `GImGui` being undefined.
+Have I missed something there during the library build?! I don't know.
+
+If the ImPlot binding is separate from ImGui binding (cleanest approach), I'm not sure how
+the user script would behave if pyimgui and pyimplot would be based of different ImGui C++ code.
+Might be a non-issue, but I just do not know.
+
+Have any ideas or suggestions on the above topics? Bring them up, please!
+
+
+
 # Installation
 
 **pyimgui** is available on PyPI so you can easily install it with `pip`:
- 
+
     pip install imgui[full]
 
 Above command will install `imgui` package with additional dependencies for all
@@ -96,8 +151,8 @@ activated virtual environment using `virtualenv` or `python -m venv` (for newer
 Python releases). Then you can just run:
 
     make build
-    
-This command will bootstrap whole environment (pull git submodules, install 
+
+This command will bootstrap whole environment (pull git submodules, install
 dev requirements etc.) and build the project. `make` will automatically install
 `imgui` in the *development/editable* mode. Then you can run some examples
 found in the `doc/examples` directory in order to verify if project is working.

--- a/doc/examples/integrations_glfw3_implot.py
+++ b/doc/examples/integrations_glfw3_implot.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+import glfw
+import OpenGL.GL as gl
+
+import imgui
+from imgui.integrations.glfw import GlfwRenderer
+from testwindow import show_test_window
+
+def main():
+    # imgui.create_context()
+    ctx = imgui.create_context()
+    imgui.plot.create_context()
+    imgui.plot.set_imgui_context(ctx)
+    window = impl_glfw_init()
+    impl = GlfwRenderer(window)
+
+    while not glfw.window_should_close(window):
+        glfw.poll_events()
+        impl.process_inputs()
+
+        imgui.new_frame()
+
+        if imgui.begin_main_menu_bar():
+            if imgui.begin_menu("File", True):
+
+                clicked_quit, selected_quit = imgui.menu_item(
+                    "Quit", 'Cmd+Q', False, True
+                )
+
+                if clicked_quit:
+                    exit(1)
+
+                imgui.end_menu()
+            imgui.end_main_menu_bar()
+
+
+        imgui.begin("Custom window", True)
+        imgui.text("Bar")
+        imgui.text_ansi("B\033[31marA\033[mnsi ")
+        imgui.text_ansi_colored("Eg\033[31mgAn\033[msi ", 0.2, 1., 0.)
+        imgui.extra.text_ansi_colored("Eggs", 0.2, 1., 0.)
+        imgui.end()
+
+        # XXX: not ready for prime time?
+        # show_test_window()
+        # ImGui demo
+        imgui.show_test_window()
+        # ImPlot demo
+        imgui.plot.show_demo_window(True)
+
+        gl.glClearColor(1., 1., 1., 1)
+        gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+        imgui.render()
+        impl.render(imgui.get_draw_data())
+        glfw.swap_buffers(window)
+
+    impl.shutdown()
+    glfw.terminate()
+
+
+def impl_glfw_init():
+    width, height = 1280, 720
+    window_name = "minimal ImGui/GLFW3 example"
+
+    if not glfw.init():
+        print("Could not initialize OpenGL context")
+        exit(1)
+
+    # OS X supports only forward-compatible core profiles from 3.2
+    glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+    glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
+    glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+
+    glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
+
+    # Create a windowed mode window and its OpenGL context
+    window = glfw.create_window(
+        int(width), int(height), window_name, None, None
+    )
+    glfw.make_context_current(window)
+
+    if not window:
+        glfw.terminate()
+        print("Could not initialize Window")
+        exit(1)
+
+    return window
+
+
+if __name__ == "__main__":
+    main()

--- a/imgui/__init__.py
+++ b/imgui/__init__.py
@@ -8,6 +8,7 @@ from imgui.extra import *  # noqa
 from imgui import extra
 from imgui import _compat
 from imgui import internal
+from imgui import plot
 
 # TODO: Complete and correcte doc text for ImGui v1.79
 
@@ -61,7 +62,7 @@ KEY_SPACE = core.KEY_SPACE
 KEY_ENTER = core.KEY_ENTER
 #: for text edit
 KEY_ESCAPE = core.KEY_ESCAPE
-#: 
+#:
 KEY_PAD_ENTER = core.KEY_PAD_ENTER
 #: for text edit CTRL+A: select all
 KEY_A = core.KEY_A
@@ -96,7 +97,7 @@ NAV_INPUT_DPAD_DOWN = core.NAV_INPUT_DPAD_DOWN
 #: scroll / move window (w/ PadMenu)             e.g. Left Analog Stick Left/Right/Up/Down
 NAV_INPUT_L_STICK_LEFT = core.NAV_INPUT_L_STICK_LEFT
 #:
-NAV_INPUT_L_STICK_RIGHT = core.NAV_INPUT_L_STICK_RIGHT 
+NAV_INPUT_L_STICK_RIGHT = core.NAV_INPUT_L_STICK_RIGHT
 #:
 NAV_INPUT_L_STICK_UP = core.NAV_INPUT_L_STICK_UP
 #:
@@ -370,10 +371,10 @@ COLOR_RESIZE_GRIP = core.COLOR_RESIZE_GRIP
 COLOR_RESIZE_GRIP_HOVERED = core.COLOR_RESIZE_GRIP_HOVERED
 COLOR_RESIZE_GRIP_ACTIVE = core.COLOR_RESIZE_GRIP_ACTIVE
 COLOR_TAB = COLOR_TAB
-COLOR_TAB_HOVERED = COLOR_TAB_HOVERED                           
-COLOR_TAB_ACTIVE = COLOR_TAB_ACTIVE                            
-COLOR_TAB_UNFOCUSED = COLOR_TAB_UNFOCUSED                         
-COLOR_TAB_UNFOCUSED_ACTIVE = COLOR_TAB_UNFOCUSED_ACTIVE                  
+COLOR_TAB_HOVERED = COLOR_TAB_HOVERED
+COLOR_TAB_ACTIVE = COLOR_TAB_ACTIVE
+COLOR_TAB_UNFOCUSED = COLOR_TAB_UNFOCUSED
+COLOR_TAB_UNFOCUSED_ACTIVE = COLOR_TAB_UNFOCUSED_ACTIVE
 COLOR_PLOT_LINES = core.COLOR_PLOT_LINES
 COLOR_PLOT_LINES_HOVERED = core.COLOR_PLOT_LINES_HOVERED
 COLOR_PLOT_HISTOGRAM = core.COLOR_PLOT_HISTOGRAM
@@ -392,15 +393,15 @@ COLOR_MODAL_WINDOW_DIM_BACKGROUND = core.COLOR_MODAL_WINDOW_DIM_BACKGROUND
 COLOR_COUNT = core.COLOR_COUNT
 
 # === Data Type (redefines for autodoc)
-DATA_TYPE_S8     = core.DATA_TYPE_S8    
-DATA_TYPE_U8     = core.DATA_TYPE_U8    
-DATA_TYPE_S16    = core.DATA_TYPE_S16   
-DATA_TYPE_U16    = core.DATA_TYPE_U16   
-DATA_TYPE_S32    = core.DATA_TYPE_S32   
-DATA_TYPE_U32    = core.DATA_TYPE_U32   
-DATA_TYPE_S64    = core.DATA_TYPE_S64   
-DATA_TYPE_U64    = core.DATA_TYPE_U64   
-DATA_TYPE_FLOAT  = core.DATA_TYPE_FLOAT 
+DATA_TYPE_S8     = core.DATA_TYPE_S8
+DATA_TYPE_U8     = core.DATA_TYPE_U8
+DATA_TYPE_S16    = core.DATA_TYPE_S16
+DATA_TYPE_U16    = core.DATA_TYPE_U16
+DATA_TYPE_S32    = core.DATA_TYPE_S32
+DATA_TYPE_U32    = core.DATA_TYPE_U32
+DATA_TYPE_S64    = core.DATA_TYPE_S64
+DATA_TYPE_U64    = core.DATA_TYPE_U64
+DATA_TYPE_FLOAT  = core.DATA_TYPE_FLOAT
 DATA_TYPE_DOUBLE = core.DATA_TYPE_DOUBLE
 
 
@@ -551,7 +552,7 @@ TABLE_NO_PAD_OUTER_X    = core.TABLE_NO_PAD_OUTER_X
 TABLE_NO_PAD_INNER_X    = core.TABLE_NO_PAD_INNER_X
 #: # Scrolling
 #: Enable horizontal scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size. Changes default sizing policy. Because this create a child window, ScrollY is currently generally recommended when using ScrollX.
-TABLE_SCROLL_X = core.TABLE_SCROLL_X 
+TABLE_SCROLL_X = core.TABLE_SCROLL_X
 #: Enable vertical scrolling. Require 'outer_size' parameter of BeginTable() to specify the container size.
 TABLE_SCROLL_Y = core.TABLE_SCROLL_Y
 #: # Sorting
@@ -707,7 +708,7 @@ DIRECTION_UP = core.DIRECTION_UP
 DIRECTION_DOWN = core.DIRECTION_DOWN
 
 # === Sorting direction
-SORT_DIRECTION_NONE  = core.SORT_DIRECTION_NONE 
+SORT_DIRECTION_NONE  = core.SORT_DIRECTION_NONE
 #: Ascending = 0->9, A->Z etc.
 SORT_DIRECTION_ASCENDING = core.SORT_DIRECTION_ASCENDING
 #: Descending = 9->0, Z->A etc.
@@ -796,27 +797,27 @@ DRAW_CORNER_ALL = core.DRAW_CORNER_ALL
 #: None
 DRAW_NONE                        = core.DRAW_NONE
 #: path_stroke(), add_polyline(): specify that shape should be closed (Important: this is always == 1 for legacy reason)
-DRAW_CLOSED                      = core.DRAW_CLOSED                     
+DRAW_CLOSED                      = core.DRAW_CLOSED
 #: add_rect(), add_rect_filled(), path_rect(): enable rounding top-left corner only (when rounding > 0.0f, we default to all corners). Was 0x01.
-DRAW_ROUND_CORNERS_TOP_LEFT      = core.DRAW_ROUND_CORNERS_TOP_LEFT     
+DRAW_ROUND_CORNERS_TOP_LEFT      = core.DRAW_ROUND_CORNERS_TOP_LEFT
 #: add_rect(), add_rect_filled(), path_rect(): enable rounding top-right corner only (when rounding > 0.0f, we default to all corners). Was 0x02.
-DRAW_ROUND_CORNERS_TOP_RIGHT     = core.DRAW_ROUND_CORNERS_TOP_RIGHT    
+DRAW_ROUND_CORNERS_TOP_RIGHT     = core.DRAW_ROUND_CORNERS_TOP_RIGHT
 #: add_rect(), add_rect_filled(), path_rect(): enable rounding bottom-left corner only (when rounding > 0.0f, we default to all corners). Was 0x04.
-DRAW_ROUND_CORNERS_BOTTOM_LEFT   = core.DRAW_ROUND_CORNERS_BOTTOM_LEFT  
+DRAW_ROUND_CORNERS_BOTTOM_LEFT   = core.DRAW_ROUND_CORNERS_BOTTOM_LEFT
 #: add_rect(), add_rect_filled(), path_rect(): enable rounding bottom-right corner only (when rounding > 0.0f, we default to all corners). Wax 0x08.
-DRAW_ROUND_CORNERS_BOTTOM_RIGHT  = core.DRAW_ROUND_CORNERS_BOTTOM_RIGHT 
+DRAW_ROUND_CORNERS_BOTTOM_RIGHT  = core.DRAW_ROUND_CORNERS_BOTTOM_RIGHT
 #: add_rect(), add_rect_filled(), path_rect(): disable rounding on all corners (when rounding > 0.0f). This is NOT zero, NOT an implicit flag!
-DRAW_ROUND_CORNERS_NONE          = core.DRAW_ROUND_CORNERS_NONE         
+DRAW_ROUND_CORNERS_NONE          = core.DRAW_ROUND_CORNERS_NONE
 #: DRAW_ROUND_CORNERS_TOP_LEFT | DRAW_ROUND_CORNERS_TOP_RIGHT
-DRAW_ROUND_CORNERS_TOP           = core.DRAW_ROUND_CORNERS_TOP          
+DRAW_ROUND_CORNERS_TOP           = core.DRAW_ROUND_CORNERS_TOP
 #: DRAW_ROUND_CORNERS_BOTTOM_LEFT | DRAW_ROUND_CORNERS_BOTTOM_RIGHT
-DRAW_ROUND_CORNERS_BOTTOM        = core.DRAW_ROUND_CORNERS_BOTTOM       
+DRAW_ROUND_CORNERS_BOTTOM        = core.DRAW_ROUND_CORNERS_BOTTOM
 #: DRAW_ROUND_CORNERS_BOTTOM_LEFT | DRAW_ROUND_CORNERS_TOP_LEFT
-DRAW_ROUND_CORNERS_LEFT          = core.DRAW_ROUND_CORNERS_LEFT         
+DRAW_ROUND_CORNERS_LEFT          = core.DRAW_ROUND_CORNERS_LEFT
 #: DRAW_ROUND_CORNERS_BOTTOM_RIGHT | DRAW_ROUND_CORNERS_TOP_RIGHT
-DRAW_ROUND_CORNERS_RIGHT         = core.DRAW_ROUND_CORNERS_RIGHT        
+DRAW_ROUND_CORNERS_RIGHT         = core.DRAW_ROUND_CORNERS_RIGHT
 #: DRAW_ROUND_CORNERS_TOP_LEFT | DRAW_ROUND_CORNERS_TOP_RIGHT | DRAW_ROUND_CORNERS_BOTTOM_LEFT | DRAW_ROUND_CORNERS_BOTTOM_RIGHT
-DRAW_ROUND_CORNERS_ALL           = core.DRAW_ROUND_CORNERS_ALL          
+DRAW_ROUND_CORNERS_ALL           = core.DRAW_ROUND_CORNERS_ALL
 
 # === Draw List Flags (redefines for autodoc)
 DRAW_LIST_NONE = core.DRAW_LIST_NONE
@@ -852,18 +853,18 @@ BACKEND_RENDERER_HAS_VTX_OFFSET = core.BACKEND_RENDERER_HAS_VTX_OFFSET
 # === Slider flag (redefines for autodoc)
 SLIDER_FLAGS_NONE
 #: Clamp value to min/max bounds when input manually with CTRL+Click. By default CTRL+Click allows going out of bounds.
-SLIDER_FLAGS_ALWAYS_CLAMP 
+SLIDER_FLAGS_ALWAYS_CLAMP
 #: Make the widget logarithmic (linear otherwise). Consider using ImGuiSliderFlags_NoRoundToFormat with this if using a format-string with small amount of digits.
-SLIDER_FLAGS_LOGARITHMIC 
+SLIDER_FLAGS_LOGARITHMIC
 #: Disable rounding underlying value to match precision of the display format string (e.g. %.3f values are rounded to those 3 digits)
-SLIDER_FLAGS_NO_ROUND_TO_FORMAT 
+SLIDER_FLAGS_NO_ROUND_TO_FORMAT
 #: Disable CTRL+Click or Enter key allowing to input text directly into the widget
-SLIDER_FLAGS_NO_INPUT 
+SLIDER_FLAGS_NO_INPUT
 
 # === Mouse Button (redefines for autodoc)
 MOUSE_BUTTON_LEFT = core.MOUSE_BUTTON_LEFT
 MOUSE_BUTTON_RIGHT = core.MOUSE_BUTTON_RIGHT
-MOUSE_BUTTON_MIDDLE = core.MOUSE_BUTTON_MIDDLE 
+MOUSE_BUTTON_MIDDLE = core.MOUSE_BUTTON_MIDDLE
 
 # === Viewport Flags (redifines for autodoc)
 #: None
@@ -873,5 +874,5 @@ VIEWPORT_FLAGS_IS_PLATFORM_WINDOW  = core.VIEWPORT_FLAGS_IS_PLATFORM_WINDOW
 #: Represent a Platform Monitor (unused yet)
 VIEWPORT_FLAGS_IS_PLATFORM_MONITOR = core.VIEWPORT_FLAGS_IS_PLATFORM_MONITOR
 #: Platform Window: is created/managed by the application (rather than a dear imgui backend)
-VIEWPORT_FLAGS_OWNED_BY_APP        = core.VIEWPORT_FLAGS_OWNED_BY_APP         
+VIEWPORT_FLAGS_OWNED_BY_APP        = core.VIEWPORT_FLAGS_OWNED_BY_APP
 

--- a/imgui/cimplot.pxd
+++ b/imgui/cimplot.pxd
@@ -1,0 +1,960 @@
+# -*- coding: utf-8 -*-
+# distutils: language = c++
+# distutils: include_dirs = implot-cpp
+"""
+Notes:
+   `✓` marks API element as already mapped in core bindings.
+   `✗` marks API element as "yet to be mapped
+"""
+from libcpp cimport bool
+
+from cimgui cimport ImVec2, ImVec4
+from internal cimport ImTextureID, ImGuiCond, ImGuiMouseButton, ImGuiKeyModFlags, ImGuiDragDropFlags, ImU32, ImDrawList, ImGuiContext
+
+# Must be outside cdef extern from "implot.h" since it is not defined there
+ctypedef ImPlotPoint (*ImPlotGetterCallback)(void* data, int idx)
+
+cdef extern from "implot.h":
+    #-----------------------------------------------------------------------------
+    # Forward Declarations and Basic Types
+    #-----------------------------------------------------------------------------
+
+    # Forward declarations
+    ctypedef struct ImPlotContext
+
+    # Enums/Flags
+    ctypedef int ImPlotFlags
+    ctypedef int ImPlotAxisFlags
+    ctypedef int ImPlotCol
+    ctypedef int ImPlotStyleVar
+    ctypedef int ImPlotMarker
+    ctypedef int ImPlotColormap
+    ctypedef int ImPlotLocation
+    ctypedef int ImPlotOrientation
+    ctypedef int ImPlotYAxis
+    ctypedef int ImPlotBin
+
+    # Options for plots.
+    ctypedef enum ImPlotFlags_:
+        ImPlotFlags_None,
+        ImPlotFlags_NoTitle,
+        ImPlotFlags_NoLegend,
+        ImPlotFlags_NoMenus,
+        ImPlotFlags_NoBoxSelect,
+        ImPlotFlags_NoMousePos,
+        ImPlotFlags_NoHighlight,
+        ImPlotFlags_NoChild,
+        ImPlotFlags_Equal,
+        ImPlotFlags_YAxis2,
+        ImPlotFlags_YAxis3,
+        ImPlotFlags_Query,
+        ImPlotFlags_Crosshairs,
+        ImPlotFlags_AntiAliased,
+        ImPlotFlags_CanvasOnly,
+
+    # Options for plot axes (X and Y).
+    ctypedef enum ImPlotAxisFlags_:
+        ImPlotAxisFlags_None,
+        ImPlotAxisFlags_NoLabel,
+        ImPlotAxisFlags_NoGridLines,
+        ImPlotAxisFlags_NoTickMarks,
+        ImPlotAxisFlags_NoTickLabels,
+        ImPlotAxisFlags_LogScale,
+        ImPlotAxisFlags_Time,
+        ImPlotAxisFlags_Invert,
+        ImPlotAxisFlags_AutoFit,
+        ImPlotAxisFlags_LockMin,
+        ImPlotAxisFlags_LockMax,
+        ImPlotAxisFlags_Lock,
+        ImPlotAxisFlags_NoDecorations,
+
+    # Plot styling colors.
+    ctypedef enum ImPlotCol_:
+        # item styling colors
+        ImPlotCol_Line,
+        ImPlotCol_Fill,
+        ImPlotCol_MarkerOutline,
+        ImPlotCol_MarkerFill,
+        ImPlotCol_ErrorBar,
+        # plot styling colors
+        ImPlotCol_FrameBg,
+        ImPlotCol_PlotBg,
+        ImPlotCol_PlotBorder,
+        ImPlotCol_LegendBg,
+        ImPlotCol_LegendBorder,
+        ImPlotCol_LegendText,
+        ImPlotCol_TitleText,
+        ImPlotCol_InlayText,
+        ImPlotCol_XAxis,
+        ImPlotCol_XAxisGrid,
+        ImPlotCol_YAxis,
+        ImPlotCol_YAxisGrid,
+        ImPlotCol_YAxis2,
+        ImPlotCol_YAxisGrid2,
+        ImPlotCol_YAxis3,
+        ImPlotCol_YAxisGrid3,
+        ImPlotCol_Selection,
+        ImPlotCol_Query,
+        ImPlotCol_Crosshairs,
+        ImPlotCol_COUNT
+
+    # Plot styling variables.
+    ctypedef enum ImPlotStyleVar_:
+        # item styling variables
+        ImPlotStyleVar_LineWeight,
+        ImPlotStyleVar_Marker,
+        ImPlotStyleVar_MarkerSize,
+        ImPlotStyleVar_MarkerWeight,
+        ImPlotStyleVar_FillAlpha,
+        ImPlotStyleVar_ErrorBarSize,
+        ImPlotStyleVar_ErrorBarWeight,
+        ImPlotStyleVar_DigitalBitHeight,
+        ImPlotStyleVar_DigitalBitGap,
+        # plot styling variables
+        ImPlotStyleVar_PlotBorderSize,
+        ImPlotStyleVar_MinorAlpha,
+        ImPlotStyleVar_MajorTickLen,
+        ImPlotStyleVar_MinorTickLen,
+        ImPlotStyleVar_MajorTickSize,
+        ImPlotStyleVar_MinorTickSize,
+        ImPlotStyleVar_MajorGridSize,
+        ImPlotStyleVar_MinorGridSize,
+        ImPlotStyleVar_PlotPadding,
+        ImPlotStyleVar_LabelPadding,
+        ImPlotStyleVar_LegendPadding,
+        ImPlotStyleVar_LegendInnerPadding,
+        ImPlotStyleVar_LegendSpacing,
+        ImPlotStyleVar_MousePosPadding,
+        ImPlotStyleVar_AnnotationPadding,
+        ImPlotStyleVar_FitPadding,
+        ImPlotStyleVar_PlotDefaultSize,
+        ImPlotStyleVar_PlotMinSize,
+        ImPlotStyleVar_COUNT
+
+    # Marker specifications.
+    ctypedef enum ImPlotMarker_:
+        ImPlotMarker_None,
+        ImPlotMarker_Circle,
+        ImPlotMarker_Square,
+        ImPlotMarker_Diamond,
+        ImPlotMarker_Up,
+        ImPlotMarker_Down,
+        ImPlotMarker_Left,
+        ImPlotMarker_Right,
+        ImPlotMarker_Cross,
+        ImPlotMarker_Plus,
+        ImPlotMarker_Asterisk,
+        ImPlotMarker_COUNT
+
+    # Built-in colormaps
+    ctypedef enum ImPlotColormap_:
+        ImPlotColormap_Deep,
+        ImPlotColormap_Dark,
+        ImPlotColormap_Pastel,
+        ImPlotColormap_Paired,
+        ImPlotColormap_Viridis,
+        ImPlotColormap_Plasma,
+        ImPlotColormap_Hot,
+        ImPlotColormap_Cool,
+        ImPlotColormap_Pink,
+        ImPlotColormap_Jet,
+        ImPlotColormap_Twilight,
+        ImPlotColormap_RdBu,
+        ImPlotColormap_BrBG,
+        ImPlotColormap_PiYG,
+        ImPlotColormap_Spectral,
+        ImPlotColormap_Greys,
+
+    # Used to position items on a plot (e.g. legends, labels, etc.)
+    ctypedef enum ImPlotLocation_:
+        ImPlotLocation_Center,
+        ImPlotLocation_North,
+        ImPlotLocation_South,
+        ImPlotLocation_West,
+        ImPlotLocation_East,
+        ImPlotLocation_NorthWest,
+        ImPlotLocation_NorthEast,
+        ImPlotLocation_SouthWest,
+        ImPlotLocation_SouthEast,
+
+    # Used to orient items on a plot (e.g. legends, labels, etc.)
+    ctypedef enum ImPlotOrientation_:
+        ImPlotOrientation_Horizontal,
+        ImPlotOrientation_Vertical
+
+    # Enums for different y-axes.
+    ctypedef enum ImPlotYAxis_:
+        ImPlotYAxis_1
+        ImPlotYAxis_2
+        ImPlotYAxis_3
+
+    # Enums for different automatic histogram binning methods (k = bin count or w = bin width)
+    ctypedef enum ImPlotBin_:
+        ImPlotBin_Sqrt,
+        ImPlotBin_Sturges,
+        ImPlotBin_Rice,
+        ImPlotBin_Scott,
+
+    # Double precision version of ImVec2 used by ImPlot. Extensible by end users.
+    ctypedef struct ImPlotPoint:
+        double x
+        double y
+
+    # A range defined by a min/max value. Used for plot axes ranges.
+    ctypedef struct ImPlotRange:
+        double Min
+        double Max
+
+    # Combination of two ranges for X and Y axes.
+    ctypedef struct ImPlotLimits:
+        ImPlotRange X
+        ImPlotRange Y
+
+    # Plot style structure
+    cdef cppclass ImPlotStyle:
+        # item styling variables
+        float   LineWeight
+        int     Marker
+        float   MarkerSize
+        float   MarkerWeight
+        float   FillAlpha
+        float   ErrorBarSize
+        float   ErrorBarWeight
+        float   DigitalBitHeight
+        float   DigitalBitGap
+        # plot styling variables
+        float   PlotBorderSize
+        float   MinorAlpha
+        ImVec2  MajorTickLen
+        ImVec2  MinorTickLen
+        ImVec2  MajorTickSize
+        ImVec2  MinorTickSize
+        ImVec2  MajorGridSize
+        ImVec2  MinorGridSize
+        ImVec2  PlotPadding
+        ImVec2  LabelPadding
+        ImVec2  LegendPadding
+        ImVec2  LegendInnerPadding
+        ImVec2  LegendSpacing
+        ImVec2  MousePosPadding
+        ImVec2  AnnotationPadding
+        ImVec2  FitPadding
+        ImVec2  PlotDefaultSize
+        ImVec2  PlotMinSize
+        # colors
+        ImVec4  *Colors                                     #original: ImVec4  Colors[ImPlotCol_COUNT]
+        # colormap
+        ImPlotColormap Colormap
+        # settings/flags
+        bool    AntiAliasedLines
+        bool    UseLocalTime
+        bool    UseISO8601
+        bool    Use24HourClock
+
+cdef extern from "implot.h" namespace "ImPlot":
+
+    #-----------------------------------------------------------------------------
+    #  ImPlot Context
+    #-----------------------------------------------------------------------------
+    ImPlotContext* CreateContext() except + # ✓
+    void DestroyContext( # ✓
+        ImPlotContext* ctx                  # = NULL
+        ) except +
+    ImPlotContext* GetCurrentContext() except + # ✓
+    void SetCurrentContext(ImPlotContext* ctx) except + # ✓
+    void SetImGuiContext(ImGuiContext* ctx) except + # ✓
+
+    #-----------------------------------------------------------------------------
+    #  Begin/End Plot
+    #-----------------------------------------------------------------------------
+    bool BeginPlot( # ✓
+        const char* title_id,
+        const char* x_label,                # = NULL
+        const char* y_label,                # = NULL
+        const ImVec2& size,                 # = ImVec2(-1,0)
+        ImPlotFlags flags,                  # = ImPlotFlags_None
+        ImPlotAxisFlags x_flags,            # = ImPlotAxisFlags_None
+        ImPlotAxisFlags y_flags,            # = ImPlotAxisFlags_None
+        ImPlotAxisFlags y2_flags,           # = ImPlotAxisFlags_NoGridLines
+        ImPlotAxisFlags y3_flags,           # = ImPlotAxisFlags_NoGridLines
+        const char* y2_label,               # = NULL
+        const char* y3_label,               # = NULL
+        ) except +
+    void EndPlot() except + # ✓
+
+    #-----------------------------------------------------------------------------
+    #  Plot Items
+    #-----------------------------------------------------------------------------
+    void PlotLine1 "ImPlot::PlotLine"[T]( # ✓
+        const char* label_id,
+        const T* values,
+        int count,
+        double xscale,                      # =1,
+        double x0,                          # =0,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotLine2 "ImPlot::PlotLine"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotLineG( # ✓
+        const char* label_id,
+        ImPlotGetterCallback callback,
+        void* data,
+        int count,
+        int offset,                         # =0
+        ) except +
+    void PlotScatter1 "ImPlot::PlotScatter"[T]( # ✓
+        const char* label_id,
+        const T* values,
+        int count,
+        double xscale,                      # =1,
+        double x0,                          # =0,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotScatter2 "ImPlot::PlotScatter"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotScatterG( # ✓
+        const char* label_id,
+        ImPlotGetterCallback callback,
+        void* data,
+        int count,
+        int offset,                         # =0
+        ) except +
+    void PlotStairs1 "ImPlot::PlotStairs"[T]( # ✓
+        const char* label_id,
+        const T* values,
+        int count,
+        double xscale,                      # =1,
+        double x0,                          # =0,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotStairs2 "ImPlot::PlotStairs"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotStairsG( # ✓
+        const char* label_id,
+        ImPlotGetterCallback callback,
+        void* data,
+        int count,
+        int offset,                         # =0
+        ) except +
+    void PlotShaded1 "ImPlot::PlotShaded"[T]( # ✓
+        const char* label_id,
+        const T* values,
+        int count,
+        double y_ref,                       # =0,
+        double xscale,                      # =1,
+        double x0,                          # =0,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotShaded2 "ImPlot::PlotShaded"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        int count,
+        double y_ref,                       # =0,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotShaded3 "ImPlot::PlotShaded"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys1,
+        const T* ys2,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotShadedG( # ✓
+        const char* label_id,
+        ImPlotGetterCallback callback1,
+        void* data1,
+        ImPlotGetterCallback callback2,
+        void* data2,
+        int count,
+        int offset,                         # =0
+        ) except +
+    void PlotBars1 "ImPlot::PlotBars"[T]( # ✓
+        const char* label_id,
+        const T* values,
+        int count,
+        double width,                       # =0.67,
+        double shift,                       # =0,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotBars2 "ImPlot::PlotBars"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        int count,
+        double width,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotBarsG( # ✓
+        const char* label_id,
+        ImPlotGetterCallback callback,
+        void* data,
+        int count,
+        double width,
+        int offset,                         # =0
+        ) except +
+    void PlotBarsH1 "ImPlot::PlotBarsH"[T]( # ✓
+        const char* label_id,
+        const T* values,
+        int count,
+        double height,                      # =0.67,
+        double shift,                       # =0,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotBarsH2 "ImPlot::PlotBarsH"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        int count,
+        double height,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotBarsHG( # ✓
+        const char* label_id,
+        ImPlotGetterCallback callback,
+        void* data,
+        int count,
+        double height,
+        int offset,                         # =0
+        ) except +
+    void PlotErrorBars1 "ImPlot::PlotErrorBars"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        const T* err,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotErrorBars2 "ImPlot::PlotErrorBars"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        const T* neg,
+        const T* pos,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotErrorBarsH1 "ImPlot::PlotErrorBarsH"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        const T* err,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotErrorBarsH2 "ImPlot::PlotErrorBarsH"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        const T* neg,
+        const T* pos,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotStems1 "ImPlot::PlotStems"[T]( # ✓
+        const char* label_id,
+        const T* values,
+        int count,
+        double y_ref,                       # =0,
+        double xscale,                      # =1,
+        double x0,                          # =0,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotStems2 "ImPlot::PlotStems"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        int count,
+        double y_ref,                       # =0,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotVLines1 "ImPlot::PlotVLines"[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotHLines1 "ImPlot::PlotHLines"[T]( # ✓
+        const char* label_id,
+        const T* ys,
+        int count,
+        int offset,                          # =0,
+        int stride,                          # =sizeof(T)
+        ) except +
+    void PlotPieChart[T]( # ✓
+        const char* const label_ids[],
+        const T* values,
+        int count,
+        double x,
+        double y,
+        double radius,
+        bool normalize,                     # =false,
+        const char* label_fmt,              # ="%.1f",
+        double angle0,                      # =90
+        ) except +
+    void PlotHeatmap[T]( # ✓
+        const char* label_id,
+        const T* values,
+        int rows,
+        int cols,
+        double scale_min,                   # =0,
+        double scale_max,                   # =0,
+        const char* label_fmt,              # ="%.1f",
+        const ImPlotPoint& bounds_min,      # =ImPlotPoint(0,0),
+        const ImPlotPoint& bounds_max,      # =ImPlotPoint(1,1)
+        ) except +
+    double PlotHistogram[T]( # ✓
+        const char* label_id,
+        const T* values,
+        int count,
+        int bins,                           # =ImPlotBin_Sturges,
+        bool cumulative,                    # =false,
+        bool density,                       # =false,
+        ImPlotRange range,                  # =ImPlotRange(),
+        bool outliers,                      # =true,
+        double bar_scale,                   # =1.0
+        ) except +
+    double PlotHistogram2D[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        int count,
+        int x_bins,                         # =ImPlotBin_Sturges,
+        int y_bins,                         # =ImPlotBin_Sturges,
+        bool density,                       # =false,
+        ImPlotLimits range,                 # =ImPlotLimits(),
+        bool outliers                       # =true
+        ) except +
+    void PlotDigital[T]( # ✓
+        const char* label_id,
+        const T* xs,
+        const T* ys,
+        int count,
+        int offset,                         # =0,
+        int stride,                         # =sizeof(T)
+        ) except +
+    void PlotDigitalG( # ✓
+        const char* label_id,
+        ImPlotGetterCallback callback,
+        void* data,
+        int count,
+        int offset,                         # =0
+        ) except +
+    void PlotImage( # ✓
+        const char* label_id,
+        ImTextureID user_texture_id,
+        const ImPlotPoint& bounds_min,
+        const ImPlotPoint& bounds_max,
+        const ImVec2& uv0,                  # =ImVec2(0,0),
+        const ImVec2& uv1,                  # =ImVec2(1,1),
+        const ImVec4& tint_col,             # =ImVec4(1,1,1,1)
+        ) except +
+    void PlotText( # ✓
+        const char* text,
+        double x,
+        double y,
+        bool vertical,                      # =false,
+        const ImVec2& pix_offset,           # =ImVec2(0,0)
+        ) except +
+    void PlotDummy(const char* label_id) except + # ✓
+
+    #-----------------------------------------------------------------------------
+    # Plot Utils
+    #-----------------------------------------------------------------------------
+    void SetNextPlotLimits( # ✓
+        double xmin,
+        double xmax,
+        double ymin,
+        double ymax,
+        ImGuiCond cond,                     # = ImGuiCond_Once
+        ) except +
+    void SetNextPlotLimitsX( # ✓
+        double xmin,
+        double xmax,
+        ImGuiCond cond,                     # = ImGuiCond_Once
+        ) except +
+    void SetNextPlotLimitsY( # ✓
+        double ymin,
+        double ymax,
+        ImGuiCond cond,                     # = ImGuiCond_Once,
+        ImPlotYAxis y_axis,                 # = 0
+        ) except +
+    void LinkNextPlotLimits( # ✗
+        double* xmin,
+        double* xmax,
+        double* ymin,
+        double* ymax,
+        double* ymin2,                      # = NULL,
+        double* ymax2,                      # = NULL,
+        double* ymin3,                      # = NULL,
+        double* ymax3,                      # = NULL
+        ) except +
+    void FitNextPlotAxes( # ✓
+        bool x,                             # = true,
+        bool y,                             # = true,
+        bool y2,                            # = true,
+        bool y3,                            # = true
+        ) except +
+    void SetNextPlotTicksX( # ✓
+        const double* values,
+        int n_ticks,
+        const char* const labels[],         # = NULL,
+        bool show_default,                  # = false
+        ) except +
+    void SetNextPlotTicksX( # ✓
+        double x_min,
+        double x_max,
+        int n_ticks,
+        const char* const labels[],         # = NULL,
+        bool show_default,                  # = false
+        ) except +
+    void SetNextPlotTicksY( # ✓
+        const double* values,
+        int n_ticks,
+        const char* const labels[],         # = NULL,
+        bool show_default,                  # = false,
+        ImPlotYAxis y_axis,                 # = 0
+        ) except +
+    void SetNextPlotTicksY( # ✓
+        double y_min,
+        double y_max,
+        int n_ticks,
+        const char* const labels[],         # = NULL,
+        bool show_default,                  # = false,
+        ImPlotYAxis y_axis,                 # = 0
+        ) except +
+    void SetPlotYAxis(ImPlotYAxis y_axis) except + # ✓
+    void HideNextItem( # ✓
+        bool hidden,                        # = true,
+        ImGuiCond cond,                     # = ImGuiCond_Once
+        ) except +
+    ImPlotPoint PixelsToPlot( # ✓
+        const ImVec2& pix,
+        ImPlotYAxis y_axis,                 # = IMPLOT_AUTO
+        ) except +
+    ImPlotPoint PixelsToPlot( # ✓
+        float x,
+        float y,
+        ImPlotYAxis y_axis,                 # = IMPLOT_AUTO
+        ) except +
+    ImVec2 PlotToPixels( # ✓
+        const ImPlotPoint& plt,
+        ImPlotYAxis y_axis,                 # = IMPLOT_AUTO
+        ) except +
+    ImVec2 PlotToPixels( # ✓
+        double x,
+        double y,
+        ImPlotYAxis y_axis,                 # = IMPLOT_AUTO
+        ) except +
+    ImVec2 GetPlotPos() except + # ✓
+    ImVec2 GetPlotSize() except + # ✓
+    bool IsPlotHovered() except + # ✓
+    bool IsPlotXAxisHovered() except + # ✓
+    bool IsPlotYAxisHovered( # ✓
+        ImPlotYAxis y_axis,                 # = 0
+        ) except +
+    ImPlotPoint GetPlotMousePos( # ✓
+        ImPlotYAxis y_axis,                 # = IMPLOT_AUTO
+        ) except +
+    ImPlotLimits GetPlotLimits( # ✓
+        ImPlotYAxis y_axis,                 # = IMPLOT_AUTO
+        ) except +
+    bool IsPlotQueried() except + # ✓
+    ImPlotLimits GetPlotQuery( # ✓
+        ImPlotYAxis y_axis,                 # = IMPLOT_AUTO
+        ) except +
+
+    #-----------------------------------------------------------------------------
+    # Plot Tools
+    #-----------------------------------------------------------------------------
+    void Annotate( # ✓
+        double x,
+        double y,
+        const ImVec2& pix_offset,
+        const char* fmt,
+        ...
+        ) except +
+    void Annotate( # ✓
+        double x,
+        double y,
+        const ImVec2& pix_offset,
+        const ImVec4& color,
+        const char* fmt,
+        ...
+        ) except +
+    #void AnnotateV(double x,
+    #               double y,
+    #               const ImVec2& pix_offset,
+    #               const char* fmt,
+    #               va_list args
+    #             ) except +
+    #void AnnotateV(double x,
+    #               double y,
+    #               const ImVec2& pix_offset,
+    #               const ImVec4& color,
+    #               const char* fmt,
+    #               va_list args
+    #              ) except +
+    void AnnotateClamped( # ✓
+        double x,
+        double y,
+        const ImVec2& pix_offset,
+        const char* fmt,
+        ...
+        ) except +
+    void AnnotateClamped( # ✓
+        double x,
+        double y,
+        const ImVec2& pix_offset,
+        const ImVec4& color,
+        const char* fmt,
+        ...
+        ) except +
+    #void AnnotateClampedV(double x,
+    #                      double y,
+    #                      const ImVec2& pix_offset,
+    #                      const char* fmt,
+    #                      va_list args
+    #                     ) except +
+    #void AnnotateClampedV(double x,
+    #                      double y,
+    #                      const ImVec2& pix_offset,
+    #                      const ImVec4& color,
+    #                      const char* fmt,
+    #                      va_list args
+    #                     ) except +
+    bool DragLineX( # ✓
+        const char* id,
+        double* x_value,
+        bool show_label,                    # = true,
+        const ImVec4& col,                  # = IMPLOT_AUTO_COL,
+        float thickness,                    # = 1
+        ) except +
+    bool DragLineY( # ✓
+        const char* id,
+        double* y_value,
+        bool show_label,                    # = true,
+        const ImVec4& col,                  # = IMPLOT_AUTO_COL,
+        float thickness,                    # = 1
+        ) except +
+    bool DragPoint( # ✓
+        const char* id,
+        double* x,
+        double* y,
+        bool show_label,                    # = true,
+        const ImVec4& col,                  # = IMPLOT_AUTO_COL,
+        float radius,                       # = 4
+        ) except +
+
+    #-----------------------------------------------------------------------------
+    # Legend Utils and Tools
+    #-----------------------------------------------------------------------------
+    void SetLegendLocation( # ✓
+        ImPlotLocation location,
+        ImPlotOrientation orientation,      # = ImPlotOrientation_Vertical,
+        bool outside,                       # = false
+        ) except +
+    void SetMousePosLocation(ImPlotLocation location) except + # ✓
+    bool IsLegendEntryHovered(const char* label_id) except + # ✓
+    bool BeginLegendPopup( # ✓
+        const char* label_id,
+        ImGuiMouseButton mouse_button,      # = 1
+        ) except +
+    void EndLegendPopup() except + # ✓
+
+    #-----------------------------------------------------------------------------
+    # Drag and Drop Utils
+    #-----------------------------------------------------------------------------
+    bool BeginDragDropTarget() except + # ✓
+    bool BeginDragDropTargetX() except + # ✓
+    bool BeginDragDropTargetY( # ✓
+        ImPlotYAxis axis                    # = ImPlotYAxis_1
+        ) except +
+    bool BeginDragDropTargetLegend() except + # ✓
+    void EndDragDropTarget() except + # ✓
+    bool BeginDragDropSource( # ✓
+        ImGuiKeyModFlags key_mods,          # = ImGuiKeyModFlags_Ctrl,
+        ImGuiDragDropFlags flags,           # = 0
+        ) except +
+    bool BeginDragDropSourceX( # ✓
+        ImGuiKeyModFlags key_mods,          # = ImGuiKeyModFlags_Ctrl,
+        ImGuiDragDropFlags flags,           # = 0
+        ) except +
+    bool BeginDragDropSourceY( # ✓
+        ImPlotYAxis axis,                   # = ImPlotYAxis_1,
+        ImGuiKeyModFlags key_mods,          # = ImGuiKeyModFlags_Ctrl,
+        ImGuiDragDropFlags flags,           # = 0
+        ) except +
+    bool BeginDragDropSourceItem( # ✓
+        const char* label_id,
+        ImGuiDragDropFlags flags,           # = 0
+        ) except +
+    void EndDragDropSource() except + # ✓
+
+    #-----------------------------------------------------------------------------
+    # Plot and Item Styling
+    #-----------------------------------------------------------------------------
+    ImPlotStyle& GetStyle() except + # ✓
+    void StyleColorsAuto( # ✓
+        ImPlotStyle* dst                    # = NULL
+        ) except +
+    void StyleColorsClassic( # ✓
+        ImPlotStyle* dst                    # = NULL
+        ) except +
+    void StyleColorsDark( # ✓
+        ImPlotStyle* dst                    # = NULL
+        ) except +
+    void StyleColorsLight( # ✓
+        ImPlotStyle* dst                    # = NULL
+        ) except +
+    void PushStyleColor(ImPlotCol idx, ImU32 col) except + # ✗
+    void PushStyleColor(ImPlotCol idx, const ImVec4& col) except + # ✓
+    void PopStyleColor( # ✓
+        int count                           # = 1
+        ) except +
+    void PushStyleVar(ImPlotStyleVar idx, float val) except + # ✓
+    void PushStyleVar(ImPlotStyleVar idx, int val) except + # ✓
+    void PushStyleVar(ImPlotStyleVar idx, const ImVec2& val) except + # ✓
+    void PopStyleVar( # ✓
+        int count                           # = 1
+        ) except +
+    void SetNextLineStyle( # ✓
+        const ImVec4& col,                  # = IMPLOT_AUTO_COL,
+        float weight                        # = IMPLOT_AUTO
+        ) except +
+    void SetNextFillStyle( # ✓
+        const ImVec4& col,                  # = IMPLOT_AUTO_COL,
+        float alpha_mod                     # = IMPLOT_AUTO
+        ) except +
+    void SetNextMarkerStyle( # ✓
+        ImPlotMarker marker,                # = IMPLOT_AUTO,
+        float size,                         # = IMPLOT_AUTO,
+        const ImVec4& fill,                 # = IMPLOT_AUTO_COL,
+        float weight,                       # = IMPLOT_AUTO,
+        const ImVec4& outline               # = IMPLOT_AUTO_COL
+        ) except +
+    void SetNextErrorBarStyle( # ✓
+        const ImVec4& col,                  # = IMPLOT_AUTO_COL,
+        float size,                         # = IMPLOT_AUTO,
+        float weight                        # = IMPLOT_AUTO
+        ) except +
+    ImVec4 GetLastItemColor() except + # ✓
+    const char* GetStyleColorName(ImPlotCol idx) except + # ✓
+    const char* GetMarkerName(ImPlotMarker idx) except + # ✓
+
+    #-----------------------------------------------------------------------------
+    # Colormaps
+    #-----------------------------------------------------------------------------
+    ImPlotColormap AddColormap( # ✓
+        const char* name,
+        const ImVec4* cols,
+        int size,
+        bool qual                           # =true
+        ) except +
+    ImPlotColormap AddColormap( # ✗
+        const char* name,
+        const ImU32* cols,
+        int size,
+        bool qual                           # =true
+        ) except +
+    int GetColormapCount() except + # ✓
+    const char* GetColormapName(ImPlotColormap cmap) except + # ✓
+    ImPlotColormap GetColormapIndex(const char* name) except + # ✓
+    void PushColormap(ImPlotColormap cmap) except + # ✓
+    void PushColormap(const char* name) except + # ✓
+    void PopColormap( # ✓
+        int count                           # = 1
+        ) except +
+    ImVec4 NextColormapColor() except + # ✓
+    int GetColormapSize( # ✓
+        ImPlotColormap cmap                 #  = IMPLOT_AUTO
+        ) except +
+    ImVec4 GetColormapColor( # ✓
+        int idx,
+        ImPlotColormap cmap                 # = IMPLOT_AUTO
+        ) except +
+    ImVec4 SampleColormap( # ✓
+        float t,
+        ImPlotColormap cmap                 # = IMPLOT_AUTO
+        ) except +
+    void ColormapScale( # ✓
+        const char* label,
+        double scale_min,
+        double scale_max,
+        const ImVec2& size,                 # = ImVec2(0,0),
+        ImPlotColormap cmap                 # = IMPLOT_AUTO
+        ) except +
+    bool ColormapSlider( # ✓
+        const char* label,
+        float* t,
+        ImVec4* out,                        # = NULL,
+        const char* format,                 # = "",
+        ImPlotColormap cmap                 # = IMPLOT_AUTO
+        ) except +
+    bool ColormapButton( # ✓
+        const char* label,
+        const ImVec2& size,                 # = ImVec2(0,0),
+        ImPlotColormap cmap                 # = IMPLOT_AUTO
+        ) except +
+    void BustColorCache( # ✓
+        const char* plot_title_id           # = NULL
+        ) except +
+
+    #-----------------------------------------------------------------------------
+    # Miscellaneous
+    #-----------------------------------------------------------------------------
+    void ItemIcon(const ImVec4& col) except + # ✓
+    void ItemIcon(ImU32 col) except + # ✓
+    void ColormapIcon(ImPlotColormap cmap) except + # ✓
+    ImDrawList* GetPlotDrawList() except +
+    void PushPlotClipRect() except + # ✓
+    void PopPlotClipRect() except + # ✓
+    bool ShowStyleSelector(const char* label) except + # ✓
+    bool ShowColormapSelector(const char* label) except + # ✓
+    void ShowStyleEditor(ImPlotStyle* ref) except + # ✓
+    void ShowStyleEditor() except + # ✓
+    void ShowUserGuide() except + # ✓
+    void ShowMetricsWindow(bool* p_popen) except + # ✓
+    void ShowMetricsWindow() except + # ✓
+
+    #-----------------------------------------------------------------------------
+    # Demo (add implot_demo.cpp to your sources!)
+    #-----------------------------------------------------------------------------
+    void ShowDemoWindow(bool* p_open) except + # ✓
+    void ShowDemoWindow() except + # ✓

--- a/imgui/core.pxd
+++ b/imgui/core.pxd
@@ -10,3 +10,10 @@ cdef class _Font(object):
 
     @staticmethod
     cdef from_ptr(cimgui.ImFont* ptr)
+
+# allows using _ImGuiContext in plot.pyx
+cdef class _ImGuiContext(object):
+    cdef cimgui.ImGuiContext* _ptr
+
+    @staticmethod
+    cdef from_ptr(cimgui.ImGuiContext* ptr)

--- a/imgui/core.pyx
+++ b/imgui/core.pyx
@@ -78,10 +78,10 @@ STYLE_BUTTON_TEXT_ALIGN = enums.ImGuiStyleVar_ButtonTextAlign # Vec2
 STYLE_SELECTABLE_TEXT_ALIGN = enums.ImGuiStyleVar_SelectableTextAlign # Vec2
 
 # ==== Button Flags ====
-BUTTON_NONE = enums.ImGuiButtonFlags_None                   
-BUTTON_MOUSE_BUTTON_LEFT = enums.ImGuiButtonFlags_MouseButtonLeft        
-BUTTON_MOUSE_BUTTON_RIGHT = enums.ImGuiButtonFlags_MouseButtonRight       
-BUTTON_MOUSE_BUTTON_MIDDLE = enums.ImGuiButtonFlags_MouseButtonMiddle      
+BUTTON_NONE = enums.ImGuiButtonFlags_None
+BUTTON_MOUSE_BUTTON_LEFT = enums.ImGuiButtonFlags_MouseButtonLeft
+BUTTON_MOUSE_BUTTON_RIGHT = enums.ImGuiButtonFlags_MouseButtonRight
+BUTTON_MOUSE_BUTTON_MIDDLE = enums.ImGuiButtonFlags_MouseButtonMiddle
 
 # ==== Key map enum redefines ====
 KEY_TAB = enums.ImGuiKey_Tab                 # for tabbing through fields
@@ -108,11 +108,11 @@ KEY_Y = enums.ImGuiKey_Y                     # for text edit CTRL+Y: redo
 KEY_Z = enums.ImGuiKey_Z                     # for text edit CTRL+Z: undo
 
 # ==== Key Mod Flags ====
-KEY_MOD_NONE = enums.ImGuiKeyModFlags_None       
-KEY_MOD_CTRL = enums.ImGuiKeyModFlags_Ctrl       
-KEY_MOD_SHIFT = enums.ImGuiKeyModFlags_Shift      
-KEY_MOD_ALT = enums.ImGuiKeyModFlags_Alt        
-KEY_MOD_SUPER = enums.ImGuiKeyModFlags_Super     
+KEY_MOD_NONE = enums.ImGuiKeyModFlags_None
+KEY_MOD_CTRL = enums.ImGuiKeyModFlags_Ctrl
+KEY_MOD_SHIFT = enums.ImGuiKeyModFlags_Shift
+KEY_MOD_ALT = enums.ImGuiKeyModFlags_Alt
+KEY_MOD_SUPER = enums.ImGuiKeyModFlags_Super
 
 # ==== Nav Input ====
 NAV_INPUT_ACTIVATE = enums.ImGuiNavInput_Activate
@@ -142,7 +142,7 @@ WINDOW_NO_SCROLLBAR = enums.ImGuiWindowFlags_NoScrollbar
 WINDOW_NO_SCROLL_WITH_MOUSE = enums.ImGuiWindowFlags_NoScrollWithMouse
 WINDOW_NO_COLLAPSE = enums.ImGuiWindowFlags_NoCollapse
 WINDOW_ALWAYS_AUTO_RESIZE = enums.ImGuiWindowFlags_AlwaysAutoResize
-WINDOW_NO_BACKGROUND = enums.ImGuiWindowFlags_NoBackground 
+WINDOW_NO_BACKGROUND = enums.ImGuiWindowFlags_NoBackground
 WINDOW_NO_SAVED_SETTINGS = enums.ImGuiWindowFlags_NoSavedSettings
 WINDOW_NO_MOUSE_INPUTS = enums.ImGuiWindowFlags_NoMouseInputs
 WINDOW_MENU_BAR = enums.ImGuiWindowFlags_MenuBar
@@ -160,31 +160,31 @@ WINDOW_NO_DECORATION = enums.ImGuiWindowFlags_NoDecoration
 WINDOW_NO_INPUTS = enums.ImGuiWindowFlags_NoInputs
 
 # ==== Color Edit Flags ====
-COLOR_EDIT_NONE = enums.ImGuiColorEditFlags_None            
-COLOR_EDIT_NO_ALPHA = enums.ImGuiColorEditFlags_NoAlpha         
-COLOR_EDIT_NO_PICKER = enums.ImGuiColorEditFlags_NoPicker        
-COLOR_EDIT_NO_OPTIONS = enums.ImGuiColorEditFlags_NoOptions       
-COLOR_EDIT_NO_SMALL_PREVIEW = enums.ImGuiColorEditFlags_NoSmallPreview  
-COLOR_EDIT_NO_INPUTS = enums.ImGuiColorEditFlags_NoInputs        
-COLOR_EDIT_NO_TOOLTIP = enums.ImGuiColorEditFlags_NoTooltip       
-COLOR_EDIT_NO_LABEL = enums.ImGuiColorEditFlags_NoLabel         
-COLOR_EDIT_NO_SIDE_PREVIEW = enums.ImGuiColorEditFlags_NoSidePreview   
-COLOR_EDIT_NO_DRAG_DROP = enums.ImGuiColorEditFlags_NoDragDrop      
-COLOR_EDIT_NO_BORDER = enums.ImGuiColorEditFlags_NoBorder        
+COLOR_EDIT_NONE = enums.ImGuiColorEditFlags_None
+COLOR_EDIT_NO_ALPHA = enums.ImGuiColorEditFlags_NoAlpha
+COLOR_EDIT_NO_PICKER = enums.ImGuiColorEditFlags_NoPicker
+COLOR_EDIT_NO_OPTIONS = enums.ImGuiColorEditFlags_NoOptions
+COLOR_EDIT_NO_SMALL_PREVIEW = enums.ImGuiColorEditFlags_NoSmallPreview
+COLOR_EDIT_NO_INPUTS = enums.ImGuiColorEditFlags_NoInputs
+COLOR_EDIT_NO_TOOLTIP = enums.ImGuiColorEditFlags_NoTooltip
+COLOR_EDIT_NO_LABEL = enums.ImGuiColorEditFlags_NoLabel
+COLOR_EDIT_NO_SIDE_PREVIEW = enums.ImGuiColorEditFlags_NoSidePreview
+COLOR_EDIT_NO_DRAG_DROP = enums.ImGuiColorEditFlags_NoDragDrop
+COLOR_EDIT_NO_BORDER = enums.ImGuiColorEditFlags_NoBorder
 
-COLOR_EDIT_ALPHA_BAR = enums.ImGuiColorEditFlags_AlphaBar        
-COLOR_EDIT_ALPHA_PREVIEW = enums.ImGuiColorEditFlags_AlphaPreview    
+COLOR_EDIT_ALPHA_BAR = enums.ImGuiColorEditFlags_AlphaBar
+COLOR_EDIT_ALPHA_PREVIEW = enums.ImGuiColorEditFlags_AlphaPreview
 COLOR_EDIT_ALPHA_PREVIEW_HALF = enums.ImGuiColorEditFlags_AlphaPreviewHalf
-COLOR_EDIT_HDR = enums.ImGuiColorEditFlags_HDR             
-COLOR_EDIT_DISPLAY_RGB = enums.ImGuiColorEditFlags_DisplayRGB      
-COLOR_EDIT_DISPLAY_HSV = enums.ImGuiColorEditFlags_DisplayHSV      
-COLOR_EDIT_DISPLAY_HEX = enums.ImGuiColorEditFlags_DisplayHex      
-COLOR_EDIT_UINT8 = enums.ImGuiColorEditFlags_Uint8           
-COLOR_EDIT_FLOAT = enums.ImGuiColorEditFlags_Float           
-COLOR_EDIT_PICKER_HUE_BAR = enums.ImGuiColorEditFlags_PickerHueBar    
-COLOR_EDIT_PICKER_HUE_WHEEL = enums.ImGuiColorEditFlags_PickerHueWheel  
-COLOR_EDIT_INPUT_RGB = enums.ImGuiColorEditFlags_InputRGB        
-COLOR_EDIT_INPUT_HSV = enums.ImGuiColorEditFlags_InputHSV        
+COLOR_EDIT_HDR = enums.ImGuiColorEditFlags_HDR
+COLOR_EDIT_DISPLAY_RGB = enums.ImGuiColorEditFlags_DisplayRGB
+COLOR_EDIT_DISPLAY_HSV = enums.ImGuiColorEditFlags_DisplayHSV
+COLOR_EDIT_DISPLAY_HEX = enums.ImGuiColorEditFlags_DisplayHex
+COLOR_EDIT_UINT8 = enums.ImGuiColorEditFlags_Uint8
+COLOR_EDIT_FLOAT = enums.ImGuiColorEditFlags_Float
+COLOR_EDIT_PICKER_HUE_BAR = enums.ImGuiColorEditFlags_PickerHueBar
+COLOR_EDIT_PICKER_HUE_WHEEL = enums.ImGuiColorEditFlags_PickerHueWheel
+COLOR_EDIT_INPUT_RGB = enums.ImGuiColorEditFlags_InputRGB
+COLOR_EDIT_INPUT_HSV = enums.ImGuiColorEditFlags_InputHSV
 
 COLOR_EDIT_DEFAULT_OPTIONS = enums.ImGuiColorEditFlags__OptionsDefault
 
@@ -201,31 +201,31 @@ TREE_NODE_OPEN_ON_ARROW = enums.ImGuiTreeNodeFlags_OpenOnArrow
 TREE_NODE_LEAF = enums.ImGuiTreeNodeFlags_Leaf
 TREE_NODE_BULLET = enums.ImGuiTreeNodeFlags_Bullet
 TREE_NODE_FRAME_PADDING = enums.ImGuiTreeNodeFlags_FramePadding
-TREE_NODE_SPAN_AVAILABLE_WIDTH = enums.ImGuiTreeNodeFlags_SpanAvailWidth      
-TREE_NODE_SPAN_FULL_WIDTH = enums.ImGuiTreeNodeFlags_SpanFullWidth       
+TREE_NODE_SPAN_AVAILABLE_WIDTH = enums.ImGuiTreeNodeFlags_SpanAvailWidth
+TREE_NODE_SPAN_FULL_WIDTH = enums.ImGuiTreeNodeFlags_SpanFullWidth
 TREE_NODE_NAV_LEFT_JUPS_BACK_HERE = enums.ImGuiTreeNodeFlags_NavLeftJumpsBackHere
 TREE_NODE_COLLAPSING_HEADER = enums.ImGuiTreeNodeFlags_CollapsingHeader
 
 # ==== Popup Flags ====
-POPUP_NONE = enums.ImGuiPopupFlags_None                    
-POPUP_MOUSE_BUTTON_LEFT = enums.ImGuiPopupFlags_MouseButtonLeft         
-POPUP_MOUSE_BUTTON_RIGHT = enums.ImGuiPopupFlags_MouseButtonRight        
-POPUP_MOUSE_BUTTON_MIDDLE = enums.ImGuiPopupFlags_MouseButtonMiddle       
-POPUP_MOUSE_BUTTON_MASK = enums.ImGuiPopupFlags_MouseButtonMask_        
-POPUP_MOUSE_BUTTON_DEFAULT = enums.ImGuiPopupFlags_MouseButtonDefault_     
-POPUP_NO_OPEN_OVER_EXISTING_POPUP = enums.ImGuiPopupFlags_NoOpenOverExistingPopup 
-POPUP_NO_OPEN_OVER_ITEMS = enums.ImGuiPopupFlags_NoOpenOverItems         
-POPUP_ANY_POPUP_ID = enums.ImGuiPopupFlags_AnyPopupId              
-POPUP_ANY_POPUP_LEVEL = enums.ImGuiPopupFlags_AnyPopupLevel           
-POPUP_ANY_POPUP = enums.ImGuiPopupFlags_AnyPopup                
+POPUP_NONE = enums.ImGuiPopupFlags_None
+POPUP_MOUSE_BUTTON_LEFT = enums.ImGuiPopupFlags_MouseButtonLeft
+POPUP_MOUSE_BUTTON_RIGHT = enums.ImGuiPopupFlags_MouseButtonRight
+POPUP_MOUSE_BUTTON_MIDDLE = enums.ImGuiPopupFlags_MouseButtonMiddle
+POPUP_MOUSE_BUTTON_MASK = enums.ImGuiPopupFlags_MouseButtonMask_
+POPUP_MOUSE_BUTTON_DEFAULT = enums.ImGuiPopupFlags_MouseButtonDefault_
+POPUP_NO_OPEN_OVER_EXISTING_POPUP = enums.ImGuiPopupFlags_NoOpenOverExistingPopup
+POPUP_NO_OPEN_OVER_ITEMS = enums.ImGuiPopupFlags_NoOpenOverItems
+POPUP_ANY_POPUP_ID = enums.ImGuiPopupFlags_AnyPopupId
+POPUP_ANY_POPUP_LEVEL = enums.ImGuiPopupFlags_AnyPopupLevel
+POPUP_ANY_POPUP = enums.ImGuiPopupFlags_AnyPopup
 
 # ==== Selectable flags enum redefines ====
 SELECTABLE_NONE = enums.ImGuiSelectableFlags_None
 SELECTABLE_DONT_CLOSE_POPUPS = enums.ImGuiSelectableFlags_DontClosePopups
 SELECTABLE_SPAN_ALL_COLUMNS = enums.ImGuiSelectableFlags_SpanAllColumns
 SELECTABLE_ALLOW_DOUBLE_CLICK = enums.ImGuiSelectableFlags_AllowDoubleClick
-SELECTABLE_DISABLED = enums.ImGuiSelectableFlags_Disabled           
-SELECTABLE_ALLOW_ITEM_OVERLAP = enums.ImGuiSelectableFlags_AllowItemOverlap   
+SELECTABLE_DISABLED = enums.ImGuiSelectableFlags_Disabled
+SELECTABLE_ALLOW_ITEM_OVERLAP = enums.ImGuiSelectableFlags_AllowItemOverlap
 
 # ==== Combo flags enum redefines ====
 COMBO_NONE = enums.ImGuiComboFlags_None
@@ -239,28 +239,28 @@ COMBO_NO_PREVIEW = enums.ImGuiComboFlags_NoPreview
 COMBO_HEIGHT_MASK = enums.ImGuiComboFlags_HeightMask_
 
 # ==== Tab Bar Flags ====
-TAB_BAR_NONE = enums.ImGuiTabBarFlags_None                           
-TAB_BAR_REORDERABLE = enums.ImGuiTabBarFlags_Reorderable                    
-TAB_BAR_AUTO_SELECT_NEW_TABS = enums.ImGuiTabBarFlags_AutoSelectNewTabs              
-TAB_BAR_TAB_LIST_POPUP_BUTTON = enums.ImGuiTabBarFlags_TabListPopupButton             
-TAB_BAR_NO_CLOSE_WITH_MIDDLE_MOUSE_BUTTON = enums.ImGuiTabBarFlags_NoCloseWithMiddleMouseButton   
-TAB_BAR_NO_TAB_LIST_SCROLLING_BUTTONS = enums.ImGuiTabBarFlags_NoTabListScrollingButtons      
-TAB_BAR_NO_TOOLTIP = enums.ImGuiTabBarFlags_NoTooltip                      
-TAB_BAR_FITTING_POLICY_RESIZE_DOWN = enums.ImGuiTabBarFlags_FittingPolicyResizeDown        
-TAB_BAR_FITTING_POLICY_SCROLL = enums.ImGuiTabBarFlags_FittingPolicyScroll            
-TAB_BAR_FITTING_POLICY_MASK = enums.ImGuiTabBarFlags_FittingPolicyMask_             
-TAB_BAR_FITTING_POLICY_DEFAULT = enums.ImGuiTabBarFlags_FittingPolicyDefault_       
+TAB_BAR_NONE = enums.ImGuiTabBarFlags_None
+TAB_BAR_REORDERABLE = enums.ImGuiTabBarFlags_Reorderable
+TAB_BAR_AUTO_SELECT_NEW_TABS = enums.ImGuiTabBarFlags_AutoSelectNewTabs
+TAB_BAR_TAB_LIST_POPUP_BUTTON = enums.ImGuiTabBarFlags_TabListPopupButton
+TAB_BAR_NO_CLOSE_WITH_MIDDLE_MOUSE_BUTTON = enums.ImGuiTabBarFlags_NoCloseWithMiddleMouseButton
+TAB_BAR_NO_TAB_LIST_SCROLLING_BUTTONS = enums.ImGuiTabBarFlags_NoTabListScrollingButtons
+TAB_BAR_NO_TOOLTIP = enums.ImGuiTabBarFlags_NoTooltip
+TAB_BAR_FITTING_POLICY_RESIZE_DOWN = enums.ImGuiTabBarFlags_FittingPolicyResizeDown
+TAB_BAR_FITTING_POLICY_SCROLL = enums.ImGuiTabBarFlags_FittingPolicyScroll
+TAB_BAR_FITTING_POLICY_MASK = enums.ImGuiTabBarFlags_FittingPolicyMask_
+TAB_BAR_FITTING_POLICY_DEFAULT = enums.ImGuiTabBarFlags_FittingPolicyDefault_
 
 # ==== Tab Item Flags ====
-TAB_ITEM_NONE = enums.ImGuiTabItemFlags_None                          
-TAB_ITEM_UNSAVED_DOCUMENT = enums.ImGuiTabItemFlags_UnsavedDocument               
-TAB_ITEM_SET_SELECTED = enums.ImGuiTabItemFlags_SetSelected                   
-TAB_ITEM_NO_CLOSE_WITH_MIDDLE_MOUSE_BUTTON = enums.ImGuiTabItemFlags_NoCloseWithMiddleMouseButton  
-TAB_ITEM_NO_PUSH_ID = enums.ImGuiTabItemFlags_NoPushId                      
-TAB_ITEM_NO_TOOLTIP = enums.ImGuiTabItemFlags_NoTooltip                     
-TAB_ITEM_NO_REORDER = enums.ImGuiTabItemFlags_NoReorder                     
-TAB_ITEM_LEADING = enums.ImGuiTabItemFlags_Leading                       
-TAB_ITEM_TRAILING = enums.ImGuiTabItemFlags_Trailing        
+TAB_ITEM_NONE = enums.ImGuiTabItemFlags_None
+TAB_ITEM_UNSAVED_DOCUMENT = enums.ImGuiTabItemFlags_UnsavedDocument
+TAB_ITEM_SET_SELECTED = enums.ImGuiTabItemFlags_SetSelected
+TAB_ITEM_NO_CLOSE_WITH_MIDDLE_MOUSE_BUTTON = enums.ImGuiTabItemFlags_NoCloseWithMiddleMouseButton
+TAB_ITEM_NO_PUSH_ID = enums.ImGuiTabItemFlags_NoPushId
+TAB_ITEM_NO_TOOLTIP = enums.ImGuiTabItemFlags_NoTooltip
+TAB_ITEM_NO_REORDER = enums.ImGuiTabItemFlags_NoReorder
+TAB_ITEM_LEADING = enums.ImGuiTabItemFlags_Leading
+TAB_ITEM_TRAILING = enums.ImGuiTabItemFlags_Trailing
 
 # === Table Flags ===
 # Features
@@ -386,8 +386,8 @@ DIRECTION_UP = enums.ImGuiDir_Up
 DIRECTION_DOWN = enums.ImGuiDir_Down
 
 # === Sorting Direction ===
-SORT_DIRECTION_NONE = enums.ImGuiSortDirection_None      
-SORT_DIRECTION_ASCENDING = enums.ImGuiSortDirection_Ascending 
+SORT_DIRECTION_NONE = enums.ImGuiSortDirection_None
+SORT_DIRECTION_ASCENDING = enums.ImGuiSortDirection_Ascending
 SORT_DIRECTION_DESCENDING = enums.ImGuiSortDirection_Descending
 
 # ==== Mouse Cursors ====
@@ -459,16 +459,16 @@ COLOR_MODAL_WINDOW_DIM_BACKGROUND = enums.ImGuiCol_ModalWindowDimBg
 COLOR_COUNT = enums.ImGuiCol_COUNT
 
 # ==== Data Type ====
-DATA_TYPE_S8     = enums.ImGuiDataType_S8     
-DATA_TYPE_U8     = enums.ImGuiDataType_U8     
-DATA_TYPE_S16    = enums.ImGuiDataType_S16    
-DATA_TYPE_U16    = enums.ImGuiDataType_U16    
-DATA_TYPE_S32    = enums.ImGuiDataType_S32    
-DATA_TYPE_U32    = enums.ImGuiDataType_U32    
-DATA_TYPE_S64    = enums.ImGuiDataType_S64    
-DATA_TYPE_U64    = enums.ImGuiDataType_U64    
-DATA_TYPE_FLOAT  = enums.ImGuiDataType_Float  
-DATA_TYPE_DOUBLE = enums.ImGuiDataType_Double 
+DATA_TYPE_S8     = enums.ImGuiDataType_S8
+DATA_TYPE_U8     = enums.ImGuiDataType_U8
+DATA_TYPE_S16    = enums.ImGuiDataType_S16
+DATA_TYPE_U16    = enums.ImGuiDataType_U16
+DATA_TYPE_S32    = enums.ImGuiDataType_S32
+DATA_TYPE_U32    = enums.ImGuiDataType_U32
+DATA_TYPE_S64    = enums.ImGuiDataType_S64
+DATA_TYPE_U64    = enums.ImGuiDataType_U64
+DATA_TYPE_FLOAT  = enums.ImGuiDataType_Float
+DATA_TYPE_DOUBLE = enums.ImGuiDataType_Double
 
 # ==== Text input flags ====
 INPUT_TEXT_NONE = enums.ImGuiInputTextFlags_None
@@ -496,16 +496,16 @@ INPUT_TEXT_CALLBACK_EDIT = enums.ImGuiInputTextFlags_CallbackEdit
 
 # ==== Draw Corner Flags ===
 # OBSOLETED in 1.82 (from Mars 2021), use ImDrawFlags_xxx
-DRAW_CORNER_NONE = enums.ImDrawCornerFlags_None      
-DRAW_CORNER_TOP_LEFT = enums.ImDrawCornerFlags_TopLeft   
-DRAW_CORNER_TOP_RIGHT = enums.ImDrawCornerFlags_TopRight  
-DRAW_CORNER_BOTTOM_LEFT = enums.ImDrawCornerFlags_BotLeft   
-DRAW_CORNER_BOTTOM_RIGHT = enums.ImDrawCornerFlags_BotRight  
-DRAW_CORNER_TOP = enums.ImDrawCornerFlags_Top       
-DRAW_CORNER_BOTTOM = enums.ImDrawCornerFlags_Bot       
-DRAW_CORNER_LEFT = enums.ImDrawCornerFlags_Left      
-DRAW_CORNER_RIGHT = enums.ImDrawCornerFlags_Right     
-DRAW_CORNER_ALL = enums.ImDrawCornerFlags_All       
+DRAW_CORNER_NONE = enums.ImDrawCornerFlags_None
+DRAW_CORNER_TOP_LEFT = enums.ImDrawCornerFlags_TopLeft
+DRAW_CORNER_TOP_RIGHT = enums.ImDrawCornerFlags_TopRight
+DRAW_CORNER_BOTTOM_LEFT = enums.ImDrawCornerFlags_BotLeft
+DRAW_CORNER_BOTTOM_RIGHT = enums.ImDrawCornerFlags_BotRight
+DRAW_CORNER_TOP = enums.ImDrawCornerFlags_Top
+DRAW_CORNER_BOTTOM = enums.ImDrawCornerFlags_Bot
+DRAW_CORNER_LEFT = enums.ImDrawCornerFlags_Left
+DRAW_CORNER_RIGHT = enums.ImDrawCornerFlags_Right
+DRAW_CORNER_ALL = enums.ImDrawCornerFlags_All
 
 
 # ==== Draw Flags ====
@@ -523,17 +523,17 @@ DRAW_ROUND_CORNERS_RIGHT = enums.ImDrawFlags_RoundCornersRight
 DRAW_ROUND_CORNERS_ALL = enums.ImDrawFlags_RoundCornersAll
 
 # ==== Draw List Flags ====
-DRAW_LIST_NONE = enums.ImDrawListFlags_None                    
-DRAW_LIST_ANTI_ALIASED_LINES = enums.ImDrawListFlags_AntiAliasedLines        
-DRAW_LIST_ANTI_ALIASED_LINES_USE_TEX = enums.ImDrawListFlags_AntiAliasedLinesUseTex  
-DRAW_LIST_ANTI_ALIASED_FILL = enums.ImDrawListFlags_AntiAliasedFill         
-DRAW_LIST_ALLOW_VTX_OFFSET = enums.ImDrawListFlags_AllowVtxOffset      
+DRAW_LIST_NONE = enums.ImDrawListFlags_None
+DRAW_LIST_ANTI_ALIASED_LINES = enums.ImDrawListFlags_AntiAliasedLines
+DRAW_LIST_ANTI_ALIASED_LINES_USE_TEX = enums.ImDrawListFlags_AntiAliasedLinesUseTex
+DRAW_LIST_ANTI_ALIASED_FILL = enums.ImDrawListFlags_AntiAliasedFill
+DRAW_LIST_ALLOW_VTX_OFFSET = enums.ImDrawListFlags_AllowVtxOffset
 
 # ==== Font Atlas Flags ====
-FONT_ATLAS_NONE = enums.ImFontAtlasFlags_None               
-FONT_ATLAS_NO_POWER_OF_TWO_HEIGHT = enums.ImFontAtlasFlags_NoPowerOfTwoHeight 
-FONT_ATLAS_NO_MOUSE_CURSOR = enums.ImFontAtlasFlags_NoMouseCursors     
-FONT_ATLAS_NO_BAKED_LINES = enums.ImFontAtlasFlags_NoBakedLines           
+FONT_ATLAS_NONE = enums.ImFontAtlasFlags_None
+FONT_ATLAS_NO_POWER_OF_TWO_HEIGHT = enums.ImFontAtlasFlags_NoPowerOfTwoHeight
+FONT_ATLAS_NO_MOUSE_CURSOR = enums.ImFontAtlasFlags_NoMouseCursors
+FONT_ATLAS_NO_BAKED_LINES = enums.ImFontAtlasFlags_NoBakedLines
 
 # ==== Config Flags ====
 CONFIG_NONE = enums.ImGuiConfigFlags_None
@@ -561,8 +561,8 @@ SLIDER_FLAGS_NO_ROUND_TO_FORMAT = enums.ImGuiSliderFlags_NoRoundToFormat
 SLIDER_FLAGS_NO_INPUT = enums.ImGuiSliderFlags_NoInput
 
 # ==== Mouse Button ====
-MOUSE_BUTTON_LEFT = enums.ImGuiMouseButton_Left 
-MOUSE_BUTTON_RIGHT = enums.ImGuiMouseButton_Right 
+MOUSE_BUTTON_LEFT = enums.ImGuiMouseButton_Left
+MOUSE_BUTTON_RIGHT = enums.ImGuiMouseButton_Right
 MOUSE_BUTTON_MIDDLE = enums.ImGuiMouseButton_Middle
 
 # ==== Viewport Flags ====
@@ -574,7 +574,8 @@ VIEWPORT_FLAGS_OWNED_BY_APP = enums.ImGuiViewportFlags_OwnedByApp               
 include "imgui/common.pyx"
 
 cdef class _ImGuiContext(object):
-    cdef cimgui.ImGuiContext* _ptr
+    # see core.pxd
+    # cdef cimgui.ImGuiContext* _ptr
 
     @staticmethod
     cdef from_ptr(cimgui.ImGuiContext* ptr):
@@ -655,25 +656,25 @@ cdef class _DrawList(object):
     @property
     def idx_buffer_data(self):
         return <uintptr_t>self._ptr.IdxBuffer.Data
-    
+
     @property
     def flags(self):
         return self._ptr.Flags
-        
+
     @flags.setter
     def flags(self, cimgui.ImDrawListFlags flags):
         self._ptr.Flags = flags
-    
+
     def push_clip_rect(
         self,
         float clip_rect_min_x, float clip_rect_min_y,
         float clip_rect_max_x, float clip_rect_max_y,
         bool intersect_with_current_clip_rect = False
         ):
-        """Render-level scissoring. This is passed down to your render function 
-        but not used for CPU-side coarse clipping. Prefer using higher-level :func:`push_clip_rect()` 
+        """Render-level scissoring. This is passed down to your render function
+        but not used for CPU-side coarse clipping. Prefer using higher-level :func:`push_clip_rect()`
         to affect logic (hit-testing and widget culling)
-        
+
         .. wraps::
             void PushClipRect(ImVec2 clip_rect_min, ImVec2 clip_rect_max, bool intersect_with_current_clip_rect = false)
         """
@@ -682,51 +683,51 @@ cdef class _DrawList(object):
             _cast_args_ImVec2(clip_rect_max_x, clip_rect_max_y),
             intersect_with_current_clip_rect
         )
-    
+
     def push_clip_rect_full_screen(self):
         """
         .. wraps::
             void PushClipRectFullScreen()
         """
         self._ptr.PushClipRectFullScreen()
-    
+
     def pop_clip_rect(self):
-        """Render-level scisoring. 
-        
+        """Render-level scisoring.
+
         .. wraps::
             void PopClipRect()
         """
         self._ptr.PopClipRect()
-    
+
     def push_texture_id(self, texture_id):
         """
         .. wraps::
             void PushTextureID(ImTextureID texture_id)
         """
         self._ptr.PushTextureID(<void*>texture_id)
-    
-    
+
+
     def pop_texture_id(self):
         """
         .. wraps::
             void PopTextureID()
         """
         self._ptr.PopTextureID()
-    
+
     def get_clip_rect_min(self):
         """
         .. wraps::
             ImVec2 GetClipRectMin()
         """
         return _cast_ImVec2_tuple(self._ptr.GetClipRectMin())
-    
+
     def get_clip_rect_max(self):
         """
         .. wraps::
             ImVec2 GetClipRectMax()
         """
         return _cast_ImVec2_tuple(self._ptr.GetClipRectMax())
-    
+
     def add_line(
             self,
             float start_x, float start_y,
@@ -959,17 +960,17 @@ cdef class _DrawList(object):
             col,
             num_segments
         )
-    
+
     def add_ngon(
         self,
         float centre_x, float centre_y,
-        float radius, 
-        cimgui.ImU32 col, 
-        int num_segments, 
+        float radius,
+        cimgui.ImU32 col,
+        int num_segments,
         float thickness = 1.0
     ):
         """Draw a regular Ngon
-        
+
         Args:
             centre_x (float): circle centre coordinates
             centre_y (float): circle centre coordinates
@@ -987,13 +988,13 @@ cdef class _DrawList(object):
             draw_list = imgui.get_window_draw_list()
             draw_list.add_ngon(100, 60, 30, imgui.get_color_u32_rgba(1,1,0,1), 5)
             imgui.end()
-        
+
         .. wraps::
             void  AddNgon(
-                const ImVec2& center, 
-                float radius, 
-                ImU32 col, 
-                int num_segments, 
+                const ImVec2& center,
+                float radius,
+                ImU32 col,
+                int num_segments,
                 float thickness = 1.0f
             )
         """
@@ -1001,16 +1002,16 @@ cdef class _DrawList(object):
             _cast_args_ImVec2(centre_x, centre_y),
             radius, col, num_segments, thickness
         )
-    
+
     def add_ngon_filled(
         self,
         float centre_x, float centre_y,
-        float radius, 
-        cimgui.ImU32 col, 
+        float radius,
+        cimgui.ImU32 col,
         int num_segments
     ):
         """Draw a regular Ngon
-        
+
         Args:
             centre_x (float): circle centre coordinates
             centre_y (float): circle centre coordinates
@@ -1027,12 +1028,12 @@ cdef class _DrawList(object):
             draw_list = imgui.get_window_draw_list()
             draw_list.add_ngon_filled(100, 60, 30, imgui.get_color_u32_rgba(1,1,0,1), 5)
             imgui.end()
-        
+
         .. wraps::
             void  AddNgonFilled(
-                const ImVec2& center, 
-                float radius, 
-                ImU32 col, 
+                const ImVec2& center,
+                float radius,
+                ImU32 col,
                 int num_segments
             )
         """
@@ -1040,7 +1041,7 @@ cdef class _DrawList(object):
             _cast_args_ImVec2(centre_x, centre_y),
             radius, col, num_segments
         )
-    
+
     def add_text(
             self,
             float pos_x, float pos_y,
@@ -1179,13 +1180,13 @@ cdef class _DrawList(object):
     # channels
 
     def channels_split(self, int channels_count):
-        """Use to split render into layers. 
+        """Use to split render into layers.
         By switching channels to can render out-of-order (e.g. submit FG primitives before BG primitives)
         Use to minimize draw calls (e.g. if going back-and-forth between multiple clipping rectangles, prefer to append into separate channels then merge at the end)
-        
+
         Prefer using your own persistent instance of ImDrawListSplitter as you can stack them.
         Using the ImDrawList::ChannelsXXXX you cannot stack a split over another.
-        
+
         Warning - be careful with using channels as "layers".
         Child windows are always drawn after their parent, so they will
         paint over its channels.
@@ -1201,47 +1202,47 @@ cdef class _DrawList(object):
     def channels_merge(self):
         # TODO: document
         self._ptr.ChannelsMerge()
-        
+
     def prim_reserve(self, int idx_count, int vtx_count):
         """Reserve space for a number of vertices and indices.
-        You must finish filling your reserved data before calling `prim_reserve()` again, as it may 
-        reallocate or submit the intermediate results. `prim_unreserve()` can be used to release 
+        You must finish filling your reserved data before calling `prim_reserve()` again, as it may
+        reallocate or submit the intermediate results. `prim_unreserve()` can be used to release
         unused allocations.
-        
+
         Drawing a quad is 6 idx (2 triangles) with 2 sharing vertices for a total of 4 vertices.
-        
+
         Args:
             idx_count (int): Number of indices to add to IdxBuffer
             vtx_count (int): Number of verticies to add to VtxBuffer
-        
+
         .. wraps::
             void PrimReserve(int idx_count, int vtx_count)
         """
         self._ptr.PrimReserve(idx_count, vtx_count)
-    
+
     def prim_unreserve(self, int idx_count, int vtx_count):
-        """Release the a number of reserved vertices/indices from the end of the 
+        """Release the a number of reserved vertices/indices from the end of the
         last reservation made with `prim_reserve()`.
-        
+
         Args:
             idx_count (int): Number of indices to remove from IdxBuffer
             vtx_count (int): Number of verticies to remove from VtxBuffer
-        
+
         .. wraps::
             void PrimUnreserve(int idx_count, int vtx_count)
         """
         self._ptr.PrimUnreserve(idx_count, vtx_count)
-    
+
     def prim_rect(self, float a_x, float a_y, float b_x, float b_y, cimgui.ImU32 color = 0xFFFFFFFF):
         """Axis aligned rectangle (2 triangles)
         Reserve primitive space with `prim_rect()` before calling `prim_quad_UV()`.
         Each call to `prim_rect()` is 6 idx and 4 vtx.
-        
+
         Args:
             a_x, a_y (float): First rectangle point coordinates
             b_x, b_y (float): Opposite rectangle point coordinates
             color (ImU32): Color
-        
+
         .. wraps::
             void PrimRect(const ImVec2& a, const ImVec2& b, ImU32 col)
         """
@@ -1250,10 +1251,10 @@ cdef class _DrawList(object):
             _cast_args_ImVec2(b_x, b_y),
             color
         )
-    
+
     def prim_rect_UV(
-        self, 
-        float a_x, float a_y, 
+        self,
+        float a_x, float a_y,
         float b_x, float b_y,
         float uv_a_u, float uv_a_v,
         float uv_b_u, float uv_b_v,
@@ -1263,14 +1264,14 @@ cdef class _DrawList(object):
         Reserve primitive space with `prim_reserve()` before calling `prim_rect_UV()`.
         Each call to `prim_rect_UV()` is 6 idx and 4 vtx.
         Set the texture ID using `push_texture_id()`.
-        
+
         Args:
             a_x, a_y (float): First rectangle point coordinates
             b_x, b_y (float): Opposite rectangle point coordinates
             uv_a_u, uv_a_v (float): First rectangle point UV coordinates
             uv_b_u, uv_b_v (float): Opposite rectangle point UV coordinates
             color (ImU32): Color
-        
+
         .. wraps::
             void PrimRectUV(const ImVec2& a, const ImVec2& b, const ImVec2& uv_a, const ImVec2& uv_b, ImU32 col)
         """
@@ -1281,12 +1282,12 @@ cdef class _DrawList(object):
             _cast_args_ImVec2(uv_b_u, uv_b_v),
             color
         )
-    
+
     def prim_quad_UV(
-        self, 
-        float a_x, float a_y, 
-        float b_x, float b_y, 
-        float c_x, float c_y, 
+        self,
+        float a_x, float a_y,
+        float b_x, float b_y,
+        float c_x, float c_y,
         float d_x, float d_y,
         float uv_a_u, float uv_a_v,
         float uv_b_u, float uv_b_v,
@@ -1298,7 +1299,7 @@ cdef class _DrawList(object):
         Reserve primitive space with `prim_reserve()` before calling `prim_quad_UV()`.
         Each call to `prim_quad_UV()` is 6 idx and 4 vtx.
         Set the texture ID using `push_texture_id()`.
-        
+
         Args:
             a_x, a_y (float): Point 1 coordinates
             b_x, b_y (float): Point 2 coordinates
@@ -1309,7 +1310,7 @@ cdef class _DrawList(object):
             uv_c_u, uv_c_v (float): Point 3 UV coordinates
             uv_d_u, uv_d_v (float): Point 4 UV coordinates
             color (ImU32): Color
-        
+
         .. wraps::
             void PrimQuadUV(const ImVec2& a, const ImVec2& b, const ImVec2& c, const ImVec2& d, const ImVec2& uv_a, const ImVec2& uv_b, const ImVec2& uv_c, const ImVec2& uv_d, ImU32 col)
         """
@@ -1324,15 +1325,15 @@ cdef class _DrawList(object):
             _cast_args_ImVec2(uv_d_u, uv_d_v),
             color
         )
-    
+
     def prim_write_vtx(self, float pos_x, float pos_y, float u, float v, cimgui.ImU32 color = 0xFFFFFFFF):
         """Write a vertex
-        
+
         Args:
             pos_x, pos_y (float): Point coordinates
             u, v (float): Point UV coordinates
             color (ImU32): Color
-        
+
         .. wraps::
             void  PrimWriteVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)
         """
@@ -1341,26 +1342,26 @@ cdef class _DrawList(object):
             _cast_args_ImVec2(u, v),
             color
         )
-    
+
     def prim_write_idx(self, cimgui.ImDrawIdx idx):
         """Write index
-        
+
         Args:
             idx (ImDrawIdx): index to write
-        
+
         .. wraps::
             void  PrimWriteIdx(ImDrawIdx idx)
         """
         self._ptr.PrimWriteIdx(idx)
-    
+
     def prim_vtx(self, float pos_x, float pos_y, float u, float v, cimgui.ImU32 color = 0xFFFFFFFF):
         """Write vertex with unique index
-        
+
         Args:
             pos_x, pos_y (float): Point coordinates
             u, v (float): Point UV coordinates
             color (ImU32): Color
-        
+
         .. wraps::
             void PrimVtx(const ImVec2& pos, const ImVec2& uv, ImU32 col)
         """
@@ -1369,7 +1370,7 @@ cdef class _DrawList(object):
             _cast_args_ImVec2(u,v),
             color
         )
-    
+
     @property
     def commands(self):
         return [
@@ -1560,7 +1561,7 @@ cdef class GuiStyle(object):
     def window_title_align(self, value):
         self._check_ptr()
         self._ptr.WindowTitleAlign = _cast_tuple_ImVec2(value)
-        
+
     @property
     def window_menu_button_position(self):
         self._check_ptr()
@@ -1620,12 +1621,12 @@ cdef class GuiStyle(object):
     def item_inner_spacing(self, value):
         self._check_ptr()
         self._ptr.ItemInnerSpacing = _cast_tuple_ImVec2(value)
-    
+
     @property
     def cell_padding(self):
         self._check_ptr()
         return _cast_ImVec2_tuple(self._ptr.CellPadding)
-    
+
     @cell_padding.setter
     def cell_padding(self, value):
         self._check_ptr()
@@ -1700,7 +1701,7 @@ cdef class GuiStyle(object):
     def grab_rounding(self, float value):
         self._check_ptr()
         self._ptr.GrabRounding = value
-        
+
     @property
     def log_slider_deadzone(self):
         self._check_ptr()
@@ -1710,7 +1711,7 @@ cdef class GuiStyle(object):
     def log_slider_deadzone(self, float value):
         self._check_ptr()
         self._ptr.LogSliderDeadzone = value
-    
+
     @property
     def tab_rounding(self):
         self._check_ptr()
@@ -1720,7 +1721,7 @@ cdef class GuiStyle(object):
     def tab_rounding(self, float value):
         self._check_ptr()
         self._ptr.TabRounding = value
-    
+
     @property
     def tab_border_size(self):
         self._check_ptr()
@@ -1730,7 +1731,7 @@ cdef class GuiStyle(object):
     def tab_border_size(self, float value):
         self._check_ptr()
         self._ptr.TabBorderSize= value
-    
+
     @property
     def tab_min_width_for_close_button(self):
         self._check_ptr()
@@ -1740,7 +1741,7 @@ cdef class GuiStyle(object):
     def tab_min_width_for_close_button(self, float value):
         self._check_ptr()
         self._ptr.TabMinWidthForCloseButton = value
-        
+
     @property
     def color_button_position(self):
         self._check_ptr()
@@ -1760,7 +1761,7 @@ cdef class GuiStyle(object):
     def button_text_align(self, value):
         self._check_ptr()
         self._ptr.ButtonTextAlign = _cast_tuple_ImVec2(value)
-    
+
     @property
     def selectable_text_align(self):
         self._check_ptr()
@@ -1810,7 +1811,7 @@ cdef class GuiStyle(object):
     def anti_aliased_lines(self, cimgui.bool value):
         self._check_ptr()
         self._ptr.AntiAliasedLines = value
-        
+
     @property
     def anti_aliased_line_use_tex(self):
         self._check_ptr()
@@ -1840,24 +1841,24 @@ cdef class GuiStyle(object):
     def curve_tessellation_tolerance(self, float value):
         self._check_ptr()
         self._ptr.CurveTessellationTol = value
-    
+
     # OBSOLETED in 1.82 (from Mars 2021)
     @property
     def circle_segment_max_error(self):
         self._check_ptr()
         return self._ptr.CircleTessellationMaxError
-    
+
     # OBSOLETED in 1.82 (from Mars 2021)
     @circle_segment_max_error.setter
     def circle_segment_max_error(self, float value):
         self._check_ptr()
         self._ptr.CircleTessellationMaxError = value
-    
+
     @property
     def circle_tessellation_max_error(self):
         self._check_ptr()
         return self._ptr.CircleTessellationMaxError
-    
+
     @circle_tessellation_max_error.setter
     def circle_tessellation_max_error(self, float value):
         self._check_ptr()
@@ -1912,54 +1913,54 @@ cdef class _ImGuiTableColumnSortSpecs(object):
         instance = _ImGuiTableColumnSortSpecs()
         instance._ptr = ptr
         return instance
-    
+
     @property
     def column_user_id(self):
         self._require_pointer()
         return self._ptr.ColumnUserID
-    
+
     @column_user_id.setter
     def column_user_id(self, cimgui.ImGuiID column_user_id):
         self._require_pointer()
         self._ptr.ColumnUserID = column_user_id
-    
+
     @property
     def column_index(self):
         self._require_pointer()
         return self._ptr.ColumnIndex
-    
+
     @column_index.setter
     def column_index(self, cimgui.ImS16 column_index):
         self._require_pointer()
         self._ptr.ColumnIndex = column_index
-    
+
     @property
     def sort_order(self):
         self._require_pointer()
         return self._ptr.SortOrder
-    
+
     @sort_order.setter
     def sort_order(self, cimgui.ImS16 sort_order):
         self._require_pointer()
         self._ptr.SortOrder = sort_order
-    
+
     @property
     def sort_direction(self):
         self._require_pointer()
         return self._ptr.SortDirection
-    
+
     @sort_direction.setter
     def sort_direction(self, cimgui.ImGuiSortDirection sort_direction):
         self._require_pointer()
         self._ptr.SortDirection = sort_direction
 
 
-    
+
 cdef class _ImGuiTableColumnSortSpecs_array(object):
-    
+
     cdef cimgui.ImGuiTableSortSpecs* _ptr
     cdef size_t idx
-    
+
     def __init__(self):
         self.idx = 0
         pass
@@ -1977,7 +1978,7 @@ cdef class _ImGuiTableColumnSortSpecs_array(object):
         instance = _ImGuiTableColumnSortSpecs_array()
         instance._ptr = ptr
         return instance
-    
+
     cdef _get_item(self, size_t idx):
         self._require_pointer()
         if idx >= self._ptr.SpecsCount:
@@ -1985,14 +1986,14 @@ cdef class _ImGuiTableColumnSortSpecs_array(object):
         cdef size_t offset = idx*sizeof(cimgui.ImGuiTableColumnSortSpecs)
         cdef size_t pointer = <size_t>self._ptr.Specs + offset
         return _ImGuiTableColumnSortSpecs.from_ptr(<cimgui.ImGuiTableColumnSortSpecs *>pointer)
-    
+
     def __getitem__(self, idx):
         return self._get_item(idx)
-    
+
     def __iter__(self):
         self.idx = 0
         return self
-        
+
     def __next__(self):
         if self.idx < self._ptr.SpecsCount:
             item = self._get_item(self.idx)
@@ -2000,14 +2001,14 @@ cdef class _ImGuiTableColumnSortSpecs_array(object):
             return item
         else:
             raise StopIteration
-    
+
     #def __setitem__(self, idx):
     #    self._table_sort_specs._require_pointer()
 
 cdef class _ImGuiTableSortSpecs(object):
     cdef cimgui.ImGuiTableSortSpecs* _ptr
     cdef _ImGuiTableColumnSortSpecs_array specs
-    
+
     def __init__(self):
         #self.specs = _ImGuiTableColumnSortSpecs_array(self)
         pass
@@ -2026,21 +2027,21 @@ cdef class _ImGuiTableSortSpecs(object):
         instance._ptr = ptr
         instance.specs = _ImGuiTableColumnSortSpecs_array.from_ptr(ptr)
         return instance
-    
+
     @property
     def specs(self):
         return self.specs
-    
+
     @property
     def specs_count(self):
         self._require_pointer()
         return self._ptr.SpecsCount
-    
+
     @property
     def specs_dirty(self):
         self._require_pointer()
         return self._ptr.SpecsDirty
-    
+
     @specs_dirty.setter
     def specs_dirty(self, cimgui.bool specs_dirty):
         self._require_pointer()
@@ -2048,13 +2049,13 @@ cdef class _ImGuiTableSortSpecs(object):
 
 cdef class _ImGuiViewport(object):
     """Currently represents the Platform Window created by the application which is hosting our Dear ImGui windows.
-       
+
        About Main Area vs Work Area:
        - Main Area = entire viewport.
        - Work Area = entire viewport minus sections used by main menu bars (for platform windows), or by task bar (for platform monitor).
        - Windows are generally trying to stay within the Work Area of their host viewport.
     """
-    
+
     cdef cimgui.ImGuiViewport* _ptr
 
     def __init__(self):
@@ -2074,40 +2075,40 @@ cdef class _ImGuiViewport(object):
         instance = _ImGuiViewport()
         instance._ptr = ptr
         return instance
-    
+
     @property
     def flags(self):
         self._require_pointer()
         return self._ptr.Flags
-    
+
     @property
     def pos(self):
         """Main Area: Position of the viewport (Dear ImGui coordinates are the same as OS desktop/native coordinates)"""
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.Pos)
-    
+
     @property
     def size(self):
         """Main Area: Size of the viewport."""
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.Size)
-    
+
     @property
     def work_pos(self):
         """Work Area: Position of the viewport minus task bars, menus bars, status bars (>= Pos)"""
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.WorkPos)
-    
+
     @property
     def work_size(self):
         """Work Area: Size of the viewport minus task bars, menu bars, status bars (<= Size)"""
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.WorkSize)
-        
+
     def get_center(self):
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.GetCenter())
-    
+
     def get_work_center(self):
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.GetWorkCenter())
@@ -2155,17 +2156,17 @@ cdef class _DrawData(object):
     def total_vtx_count(self):
         self._require_pointer()
         return self._ptr.TotalVtxCount
-        
+
     @property
     def display_pos(self):
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.DisplayPos)
-        
+
     @property
     def display_size(self):
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.DisplaySize)
-        
+
     @property
     def frame_buffer_scale(self):
         self._require_pointer()
@@ -2294,10 +2295,10 @@ cdef class _FontAtlas(object):
 
     def get_glyph_ranges_cyrillic(self):
         return _StaticGlyphRanges.from_ptr(self._ptr.GetGlyphRangesCyrillic())
-    
+
     def get_glyph_ranges_thai(self):
         return _StaticGlyphRanges.from_ptr(self._ptr.GetGlyphRangesThai())
-    
+
     def get_glyph_ranges_vietnamese(self):
         return _StaticGlyphRanges.from_ptr(self._ptr.GetGlyphRangesVietnamese())
 
@@ -2547,11 +2548,11 @@ cdef class _IO(object):
     @config_cursor_blink.setter
     def config_cursor_blink(self, cimgui.bool value):
         self._ptr.ConfigInputTextCursorBlink = value
-    
+
     @property
     def config_drag_click_to_input_text(self):
         return self._ptr.ConfigDragClickToInputText
-    
+
     @config_drag_click_to_input_text.setter
     def config_drag_click_to_input_text(self, cimgui.bool value):
         self._ptr.ConfigDragClickToInputText = value
@@ -2560,7 +2561,7 @@ cdef class _IO(object):
     @property
     def config_windows_resize_from_edges(self):
         return self._ptr.ConfigWindowsResizeFromEdges
-    
+
     # RENAMED from config_resize_windows_from_edges
     @config_windows_resize_from_edges.setter
     def config_windows_resize_from_edges(self, cimgui.bool value):
@@ -2569,7 +2570,7 @@ cdef class _IO(object):
     @property
     def config_windows_move_from_title_bar_only(self):
         return self._ptr.ConfigWindowsMoveFromTitleBarOnly
-    
+
     @config_windows_move_from_title_bar_only.setter
     def config_windows_move_from_title_bar_only(self, cimgui.bool value):
         self._ptr.ConfigWindowsMoveFromTitleBarOnly = value
@@ -2577,21 +2578,21 @@ cdef class _IO(object):
     @property
     def config_memory_compact_timer(self):
         return self._ptr.ConfigMemoryCompactTimer
-    
+
     @config_memory_compact_timer.setter
     def config_memory_compact_timer(self, float value):
         self._ptr.ConfigMemoryCompactTimer = value
 
     @staticmethod
     cdef const char* _get_clipboard_text(void* user_data):
-        
+
         text = _io.get_clipboard_text_fn()
-        
+
         # get_clipboard_text_fn() may return None
         # (e.g. if the user copied non text data)
         if text is None:
             return ""
-        
+
         if type(text) is bytes:
             return text
         return _bytes(text)
@@ -2623,7 +2624,7 @@ cdef class _IO(object):
             self._ptr.SetClipboardTextFn = self._set_clipboard_text
         else:
             raise ValueError("func is not a callable: %s" % str(func))
-    
+
     @property
     def mouse_pos(self):
         return _cast_ImVec2_tuple(self._ptr.MousePos)
@@ -2713,7 +2714,7 @@ cdef class _IO(object):
         )
         keys_down.data = <char*>self._ptr.KeysDown
         return keys_down
-        
+
     @property
     def nav_inputs(self):
         cdef cvarray nav_inputs = cvarray(
@@ -2727,7 +2728,7 @@ cdef class _IO(object):
 
     def add_input_character(self, unsigned int c):
         self._ptr.AddInputCharacter(c)
-    
+
     def add_input_character_utf16(self, str utf16_chars):
         self._ptr.AddInputCharacterUTF16(_bytes(utf16_chars))
 
@@ -2793,30 +2794,30 @@ cdef class _IO(object):
     @property
     def mouse_delta(self):
         return _cast_ImVec2_tuple(self._ptr.MouseDelta)
-        
+
 cdef class _callback_user_info(object):
-    
+
     cdef object callback_fn
     cdef user_data
-    
+
     def __init__(self):
         pass
-    
+
     def populate(self, callback_fn, user_data):
         if callable(callback_fn):
             self.callback_fn = callback_fn
             self.user_data = user_data
         else:
             raise ValueError("callback_fn is not a callable: %s" % str(callback_fn))
-    
+
 cdef int _ImGuiInputTextCallback(cimgui.ImGuiInputTextCallbackData* data):
     cdef _ImGuiInputTextCallbackData callback_data = _ImGuiInputTextCallbackData.from_ptr(data)
     callback_data._require_pointer()
     cdef ret = (<_callback_user_info>callback_data._ptr.UserData).callback_fn(callback_data)
     return ret if ret is not None else 0
-    
+
 cdef class _ImGuiInputTextCallbackData(object):
-    
+
     cdef cimgui.ImGuiInputTextCallbackData* _ptr
 
     def __init__(self):
@@ -2838,122 +2839,122 @@ cdef class _ImGuiInputTextCallbackData(object):
             )
 
         return self._ptr != NULL
-        
+
     @property
     def event_flag(self):
         self._require_pointer()
         return self._ptr.EventFlag
-    
+
     @property
     def flags(self):
         self._require_pointer()
         return self._ptr.Flags
-        
+
     @property
     def user_data(self):
         self._require_pointer()
         return (<_callback_user_info>self._ptr.UserData).user_data
-    
+
     @property
     def event_char(self):
         self._require_pointer()
         return chr(self._ptr.EventChar)
-    
+
     @event_char.setter
     def event_char(self, str event_char):
         self._require_pointer()
         self._ptr.EventChar = ord(event_char)
-    
+
     @property
     def event_key(self):
         self._require_pointer()
         return self._ptr.EventKey
-    
+
     @property
     def buffer(self):
         self._require_pointer()
         return _from_bytes(self._ptr.Buf)
-        
+
     @property
     def buffer_text_length(self):
         self._require_pointer()
         return self._ptr.BufTextLen
-    
+
     @property
     def buffer_size(self):
         self._require_pointer()
         return self._ptr.BufSize
-    
+
     @property
     def buffer_dirty(self):
         self._require_pointer()
         return self._ptr.BufDirty
-        
+
     @buffer_dirty.setter
     def buffer_dirty(self, bool dirty):
         self._require_pointer()
         self._ptr.BufDirty = dirty
-    
+
     @property
     def cursor_pos(self):
         self._require_pointer()
         return self._ptr.CursorPos
-        
+
     @cursor_pos.setter
     def cursor_pos(self, int pos):
         self._require_pointer()
         self._ptr.CursorPos = pos
-    
+
     @property
     def selection_start(self):
         self._require_pointer()
         return self._ptr.SelectionStart
-        
+
     @selection_start.setter
     def selection_start(self, int start):
         self._require_pointer()
         self._ptr.SelectionStart = start
-    
+
     @property
     def selection_end(self):
         self._require_pointer()
         return self._ptr.SelectionEnd
-        
+
     @selection_end.setter
     def selection_end(self, int end):
         self._require_pointer()
         self._ptr.SelectionEnd = end
-    
+
     def delete_chars(self, int pos, int bytes_count):
         self._require_pointer()
         self._ptr.DeleteChars(pos, bytes_count)
-        
+
     def insert_chars(self, int pos, str text):
         self._require_pointer()
         self._ptr.InsertChars(pos, _bytes(text))
-    
+
     def select_all(self):
         self._require_pointer()
         self._ptr.SelectAll()
-    
+
     def clear_selection(self):
         self._require_pointer()
         self._ptr.ClearSelection()
-        
+
     def has_selection(self):
         self._require_pointer()
         return self._ptr.HasSelection()
-        
-        
+
+
 
 cdef void _ImGuiSizeCallback(cimgui.ImGuiSizeCallbackData* data):
     cdef _ImGuiSizeCallbackData callback_data = _ImGuiSizeCallbackData.from_ptr(data)
     callback_data._require_pointer()
     (<_callback_user_info>callback_data._ptr.UserData).callback_fn(callback_data)
     return
-    
+
 cdef class _ImGuiSizeCallbackData(object):
-    
+
     cdef cimgui.ImGuiSizeCallbackData* _ptr
 
     def __init__(self):
@@ -2975,32 +2976,32 @@ cdef class _ImGuiSizeCallbackData(object):
             )
 
         return self._ptr != NULL
-        
+
     @property
     def user_data(self):
         self._require_pointer()
         return (<_callback_user_info>self._ptr.UserData).user_data
-    
+
     @property
     def pos(self):
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.Pos)
-        
+
     @property
     def current_size(self):
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.CurrentSize)
-    
+
     @property
     def desired_size(self):
         self._require_pointer()
         return _cast_ImVec2_tuple(self._ptr.DesiredSize)
-    
+
     @desired_size.setter
     def desired_size(self, tuple size):
         self._require_pointer()
         self._ptr.DesiredSize = _cast_args_ImVec2(size[0], size[1])
-       
+
 _io = None
 def get_io():
     global _io
@@ -3174,27 +3175,27 @@ def show_demo_window(closable=False):
         cimgui.ShowDemoWindow()
 
     return opened
-    
+
 def show_about_window(closable=False):
-    """ Create About window. 
+    """ Create About window.
     Display Dear ImGui version, credits and build/system information.
-    
+
     Args:
         closable (bool): define if window is closable
-    
+
     Return:
         bool: True if window is not closed (False trigerred by close button).
-    
+
     .. wraps::
         void ShowAboutWindow(bool* p_open = NULL)
     """
     cdef cimgui.bool opened = True
-    
+
     if closable:
         cimgui.ShowAboutWindow(&opened)
     else:
         cimgui.ShowAboutWindow()
-    
+
     return opened
 
 
@@ -3245,11 +3246,11 @@ def show_metrics_window(closable=False):
 
 
 def show_style_selector(str label):
-    return cimgui.ShowStyleSelector(label)
+    return cimgui.ShowStyleSelector(_bytes(label))
 
 
 def show_font_selector(str label):
-    cimgui.ShowStyleSelector(label)
+    cimgui.ShowFontSelector(_bytes(label))
 
 
 def begin(str label, closable=False, cimgui.ImGuiWindowFlags flags=0):
@@ -3903,37 +3904,37 @@ def set_next_window_size(
 # Useful for non trivial constraints
 cdef _callback_user_info _global_next_window_size_constraints_callback_user_info = _callback_user_info()
 def set_next_window_size_constraints(
-    tuple size_min, 
+    tuple size_min,
     tuple size_max,
     object callback = None,
     user_data = None):
-    """Set next window size limits. use -1,-1 on either X/Y axis to preserve the current size. 
+    """Set next window size limits. use -1,-1 on either X/Y axis to preserve the current size.
     Sizes will be rounded down.
 
     Call before :func:`begin()`.
-    
+
     Args:
         size_min (tuple): Minimum window size, use -1 to conserve current size
         size_max (tuple): Maximum window size, use -1 to conserve current size
-        callback (callable): a callable. 
+        callback (callable): a callable.
             Callable takes an imgui._ImGuiSizeCallbackData object as argument
             Callable should return None
         user_data: Any data that the user want to use in the callback.
-    
+
     .. visual-example::
         :title: Window size constraints
         :height: 200
-        
+
         imgui.set_next_window_size_constraints((175,50), (200, 100))
         imgui.begin("Constrained Window")
         imgui.text("...")
         imgui.end()
-    
+
     .. wraps::
         void SetNextWindowSizeConstraints(
-            const ImVec2& size_min, 
-            const ImVec2& size_max, 
-            ImGuiSizeCallback custom_callback = NULL, 
+            const ImVec2& size_min,
+            const ImVec2& size_max,
+            ImGuiSizeCallback custom_callback = NULL,
             void* custom_callback_user_data = NULL
         )
 
@@ -3944,10 +3945,10 @@ def set_next_window_size_constraints(
         _callback = _ImGuiSizeCallback
         _global_next_window_size_constraints_callback_user_info.populate(callback, user_data)
         _user_data = <void*>_global_next_window_size_constraints_callback_user_info
-        
+
     cimgui.SetNextWindowSizeConstraints(
-        _cast_tuple_ImVec2(size_min), 
-        _cast_tuple_ImVec2(size_max), 
+        _cast_tuple_ImVec2(size_min),
+        _cast_tuple_ImVec2(size_max),
         _callback, _user_data)
 
 def set_next_window_content_size(float width, float height):
@@ -4161,25 +4162,25 @@ def tree_pop():
     cimgui.TreePop()
 
 def get_tree_node_to_label_spacing():
-    """Horizontal distance preceding label when using ``tree_node*()`` 
-    or ``bullet() == (g.FontSize + style.FramePadding.x*2)`` for a 
+    """Horizontal distance preceding label when using ``tree_node*()``
+    or ``bullet() == (g.FontSize + style.FramePadding.x*2)`` for a
     regular unframed TreeNode
-    
+
     Returns:
         float: spacing
-        
+
     .. visual-example::
         :auto_layout:
         :height: 100
         :width: 200
-        
+
         imgui.begin("TreeNode")
         imgui.text("<- 0px offset here")
         if imgui.tree_node("Expand me!", imgui.TREE_NODE_DEFAULT_OPEN):
             imgui.text("<- %.2fpx offset here" % imgui.get_tree_node_to_label_spacing())
             imgui.tree_pop()
         imgui.end()
-    
+
     .. wraps::
         float GetTreeNodeToLabelSpacing()
     """
@@ -4242,12 +4243,12 @@ def collapsing_header(
 
 def set_next_item_open(bool is_open, cimgui.ImGuiCond condition = 0):
     """Set next TreeNode/CollapsingHeader open state.
-    
+
     Args:
         is_open (bool):
         condition (:ref:`condition flag <condition-options>`): defines on which
             condition value should be set. Defaults to :any:`imgui.NONE`.
-    
+
     .. wraps::
         void SetNextItemOpen(bool is_open, ImGuiCond cond = 0)
     """
@@ -4388,7 +4389,7 @@ def begin_list_box(
     height = 0
 ):
     """Open a framed scrolling region.
-    
+
     For use if you want to reimplement :func:`listbox()` with custom data
     or interactions. You need to call :func:`end_list_box()` at the end.
 
@@ -4422,20 +4423,20 @@ def begin_list_box(
             const char* label,
             const ImVec2& size = ImVec2(0,0)
         )
-    
+
     """
     return cimgui.BeginListBox(
         _bytes(label),
         _cast_args_ImVec2(width, height)
     )
-    
+
 def listbox_header( # OBSOLETED in 1.81 (from February 2021)
     str label,
     width=0,
     height=0
 ):
     """*Obsoleted in imgui v1.81 from February 2021, refer to :func:`begin_list_box()`*
-    
+
     For use if you want to reimplement :func:`listbox()` with custom data
     or interactions. You need to call :func:`listbox_footer()` at the end.
 
@@ -4457,7 +4458,7 @@ def listbox_header( # OBSOLETED in 1.81 (from February 2021)
 
 def end_list_box():
     """
-    
+
     Closing the listbox, previously opened by :func:`begin_list_box()`.
 
     See :func:`begin_list_box()` for usage example.
@@ -4468,7 +4469,7 @@ def end_list_box():
     cimgui.EndListBox()
 def listbox_footer(): # OBSOLETED in 1.81 (from February 2021)
     """*Obsoleted in imgui v1.81 from February 2021, refer to :func:`end_list_box()`*
-    
+
     Closing the listbox, previously opened by :func:`listbox_header()`.
 
     See :func:`listbox_header()` for usage example.
@@ -4770,13 +4771,13 @@ def open_popup(str label, cimgui.ImGuiPopupFlags flags=0):
     cimgui.OpenPopup(_bytes(label), flags)
 
 def open_popup_on_item_click(str label = None, cimgui.ImGuiPopupFlags popup_flags = 1):
-    """Helper to open popup when clicked on last item. 
+    """Helper to open popup when clicked on last item.
     (note: actually triggers on the mouse _released_ event to be consistent with popup behaviors)
-    
+
     Args:
         label (str): label of the modal window
         flags: ImGuiWindowFlags
-    
+
     .. wraps::
         void OpenPopupOnItemClick(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1)
     """
@@ -4784,7 +4785,7 @@ def open_popup_on_item_click(str label = None, cimgui.ImGuiPopupFlags popup_flag
         cimgui.OpenPopupOnItemClick(NULL, popup_flags)
     else:
         cimgui.OpenPopupOnItemClick(_bytes(label), popup_flags)
-    
+
 
 def begin_popup(str label, cimgui.ImGuiWindowFlags flags=0):
     """Open a popup window.
@@ -4961,7 +4962,7 @@ def begin_popup_context_window(
             ImGuiPopupFlags popup_flags = 1
         )
     """
-    
+
     if label is None:
         return cimgui.BeginPopupContextWindow(
             NULL,
@@ -4982,11 +4983,11 @@ def begin_popup_context_void(str label = None, cimgui.ImGuiPopupFlags popup_flag
 
     Returns:
         opened (bool): if the context window is opened.
-    
+
     .. wraps::
         bool BeginPopupContextVoid(const char* str_id = NULL, ImGuiPopupFlags popup_flags = 1)
     """
-    
+
     if label is None:
         return cimgui.BeginPopupContextVoid( NULL, popup_flags )
     else:
@@ -4994,13 +4995,13 @@ def begin_popup_context_void(str label = None, cimgui.ImGuiPopupFlags popup_flag
 
 def is_popup_open( str label,  cimgui.ImGuiPopupFlags flags = 0):
     """Popups: test function
-    
+
     * ``is_popup_open()`` with POPUP_ANY_POPUP_ID: return true if any popup is open at the current BeginPopup() level of the popup stack.
     * ``is_popup_open()`` with POPUP_ANY_POPUP_ID + POPUP_ANY_POPUP_LEVEL: return true if any popup is open.
-    
+
     Returns:
         bool: True if the popup is open at the current ``begin_popup()`` level of the popup stack.
-    
+
     .. wraps::
         bool IsPopupOpen(const char* str_id, ImGuiPopupFlags flags = 0)
     """
@@ -5042,11 +5043,11 @@ def begin_table(
     float inner_width = 0.0
     ):
     """
-    
+
     .. wraps::
         bool BeginTable(
-            const char* str_id, 
-            int column, 
+            const char* str_id,
+            int column,
             ImGuiTableFlags flags = 0,
             const ImVec2& outer_size = ImVec2(0.0f, 0.0f),
             float inner_width = 0.0f
@@ -5062,7 +5063,7 @@ def begin_table(
 
 def end_table():
     """
-    
+
     .. wraps::
         void EndTable()
     """
@@ -5073,9 +5074,9 @@ def table_next_row(
         float min_row_height = 0.0
     ):
     """
-    
+
     .. wraps::
-        void TableNextRow( 
+        void TableNextRow(
             ImGuiTableRowFlags row_flags = 0,
             float min_row_height = 0.0f
         )
@@ -5084,7 +5085,7 @@ def table_next_row(
 
 def table_next_column():
     """
-    
+
     .. wraps::
         bool TableNextColumn()
     """
@@ -5092,12 +5093,12 @@ def table_next_column():
 
 def table_set_column_index(int column_n):
     """
-    
+
     .. wraps::
         bool TableSetColumnIndex(int column_n)
     """
     return cimgui.TableSetColumnIndex(column_n)
-    
+
 def table_setup_column(
         str label,
         cimgui.ImGuiTableColumnFlags flags = 0,
@@ -5105,10 +5106,10 @@ def table_setup_column(
         cimgui.ImU32 user_id = 0
     ):
     """
-    
+
     .. wraps::
         void TableSetupColumn(
-            const char* label, 
+            const char* label,
             ImGuiTableColumnFlags flags = 0,
             float init_width_or_weight = 0.0f,
             ImU32 user_id  = 0
@@ -5122,7 +5123,7 @@ def table_setup_column(
 
 def table_setup_scroll_freez(int cols, int rows):
     """
-    
+
     .. wraps::
         void TableSetupScrollFreeze(int cols, int rows)
     """
@@ -5130,7 +5131,7 @@ def table_setup_scroll_freez(int cols, int rows):
 
 def table_headers_row():
     """
-    
+
     .. wraps::
         void TableHeadersRow()
     """
@@ -5138,15 +5139,15 @@ def table_headers_row():
 
 def table_header(str label):
     """
-    
+
     .. wraps::
         void TableHeader(const char* label)
     """
     cimgui.TableHeader(_bytes(label))
-    
+
 def table_get_sort_specs():
     """
-    
+
     .. wraps::
         ImGuiTableSortSpecs* TableGetSortSpecs()
     """
@@ -5158,7 +5159,7 @@ def table_get_sort_specs():
 
 def table_get_column_count():
     """
-    
+
     .. wraps::
         int TableGetColumnCount()
     """
@@ -5166,25 +5167,25 @@ def table_get_column_count():
 
 def table_get_column_index():
     """
-    
+
     .. wraps::
         int TableGetColumnIndex()
     """
     return cimgui.TableGetColumnIndex()
-    
+
 def table_get_row_index():
     """
-    
+
     .. wraps::
         int TableGetRowIndex()
     """
     return cimgui.TableGetRowIndex()
-    
+
 def table_get_column_name(int column_n = -1):
     """
-    
+
     .. wraps::
-        const char* TableGetColumnName( 
+        const char* TableGetColumnName(
             int column_n  = -1
         )
     """
@@ -5192,25 +5193,25 @@ def table_get_column_name(int column_n = -1):
 
 def table_get_column_flags(int column_n = -1):
     """
-    
+
     .. wraps::
         ImGuiTableColumnFlags TableGetColumnFlags(
             int column_n = -1
         )
     """
     return cimgui.TableGetColumnFlags(column_n)
-    
+
 def table_set_background_color(
         cimgui.ImGuiTableBgTarget target,
         cimgui.ImU32 color,
         int column_n = -1
     ):
     """
-    
+
     .. wraps::
         void TableSetBgColor(
-            ImGuiTableBgTarget target, 
-            ImU32 color, 
+            ImGuiTableBgTarget target,
+            ImU32 color,
             int column_n  = -1
         )
     """
@@ -5493,7 +5494,7 @@ def arrow_button(str label, cimgui.ImGuiDir direction = DIRECTION_NONE):
 
 def invisible_button(str identifier, float width, float height, cimgui.ImGuiButtonFlags flags = 0):
     """Create invisible button.
-    
+
     Flexible button behavior without the visuals, frequently useful to build custom behaviors using the public api (along with IsItemActive, IsItemHovered, etc.)
 
     .. visual-example::
@@ -6214,7 +6215,7 @@ def drag_float_range2(
     cimgui.ImGuiSliderFlags flags = 0
     ):
     """Display drag float range widget
-    
+
     Args:
         label (str): widget label
         current_min (float): current value of minimum
@@ -6226,11 +6227,11 @@ def drag_float_range2(
         format_max (str): display format for maximum. If None, ``format`` parameter is used.
         flags: SliderFlags flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-            
+
     Returns:
         tuple: a (changed, current_min, current_max) tuple, where ``changed`` indicate
                that the value has been updated.
-    
+
     .. visual-example::
         :auto_layout:
         :width: 400
@@ -6238,36 +6239,36 @@ def drag_float_range2(
 
         vmin = 0
         vmax = 100
-        
+
         imgui.begin("Example: drag float range")
         changed, vmin, vmax = imgui.drag_float_range2( "Drag Range", vmin, vmax )
         imgui.text("Changed: %s, Range: (%.2f, %.2f)" % (changed, vmin, vmax))
         imgui.end()
-   
-    
+
+
     .. wraps::
         bool DragFloatRange2(
-            const char* label, 
-            float* v_current_min, 
-            float* v_current_max, 
-            float v_speed = 1.0f, 
-            float v_min = 0.0f, 
-            float v_max = 0.0f, 
-            const char* format = "%.3f", 
-            const char* format_max = NULL, 
+            const char* label,
+            float* v_current_min,
+            float* v_current_max,
+            float v_speed = 1.0f,
+            float v_min = 0.0f,
+            float v_max = 0.0f,
+            const char* format = "%.3f",
+            const char* format_max = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef float inout_current_min = current_min
     cdef float inout_current_max = current_max
-    
+
     cdef bytes b_format_max;
     cdef char* p_format_max = NULL
     if format_max is not None:
         b_format_max = _bytes(format_max)
         p_format_max = b_format_max
-    
+
     changed = cimgui.DragFloatRange2(
         _bytes(label),
         &inout_current_min,
@@ -6279,10 +6280,10 @@ def drag_float_range2(
         p_format_max,
         flags
     )
-    
+
     return changed, inout_current_min, inout_current_max
-    
-    
+
+
 
 def drag_int(
     str label, int value,
@@ -6528,7 +6529,7 @@ def drag_int_range2(
     cimgui.ImGuiSliderFlags flags = 0
     ):
     """Display drag int range widget
-    
+
     Args:
         label (str): widget label
         current_min (int): current value of minimum
@@ -6540,11 +6541,11 @@ def drag_int_range2(
         format_max (str): display format for maximum. If None, ``format`` parameter is used.
         flags: SliderFlags flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-            
+
     Returns:
         tuple: a (changed, current_min, current_max) tuple, where ``changed`` indicate
                that the value has been updated.
-    
+
     .. visual-example::
         :auto_layout:
         :width: 400
@@ -6552,36 +6553,36 @@ def drag_int_range2(
 
         vmin = 0
         vmax = 100
-        
+
         imgui.begin("Example: drag float range")
         changed, vmin, vmax = imgui.drag_int_range2( "Drag Range", vmin, vmax )
         imgui.text("Changed: %s, Range: (%d, %d)" % (changed, vmin, vmax))
         imgui.end()
-   
-    
+
+
     .. wraps::
         bool DragIntRange2(
-            const char* label, 
-            int* v_current_min, 
-            int* v_current_max, 
-            float v_speed = 1.0f, 
-            int v_min = 0, 
-            int v_max = 0, 
-            const char* format = "%d", 
-            const char* format_max = NULL, 
+            const char* label,
+            int* v_current_min,
+            int* v_current_max,
+            float v_speed = 1.0f,
+            int v_min = 0,
+            int v_max = 0,
+            const char* format = "%d",
+            const char* format_max = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef int inout_current_min = current_min
     cdef int inout_current_max = current_max
-    
+
     cdef bytes b_format_max;
     cdef char* p_format_max = NULL
     if format_max is not None:
         b_format_max = _bytes(format_max)
         p_format_max = b_format_max
-    
+
     changed = cimgui.DragIntRange2(
         _bytes(label),
         &inout_current_min,
@@ -6593,7 +6594,7 @@ def drag_int_range2(
         p_format_max,
         flags
     )
-    
+
     return changed, inout_current_min, inout_current_max
 
 
@@ -6608,9 +6609,9 @@ def drag_scalar(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display scalar drag widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -6622,29 +6623,29 @@ def drag_scalar(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         drag state change and the current drag content.
-    
+
     .. wraps::
         bool DragScalar(
-            const char* label, 
-            ImGuiDataType data_type, 
-            void* p_data, 
-            float v_speed, 
+            const char* label,
+            ImGuiDataType data_type,
+            void* p_data,
+            float v_speed,
             const void* p_min = NULL,
             const void* p_max = NULL,
             const char* format = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = NULL
     if min_value is not None:
         p_min = min_value
-    cdef char* p_max = NULL 
+    cdef char* p_max = NULL
     if max_value is not None:
         p_max = max_value
     cdef char* fmt = NULL
@@ -6652,7 +6653,7 @@ def drag_scalar(
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.DragScalar(
         _bytes(label),
         data_type,
@@ -6663,7 +6664,7 @@ def drag_scalar(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def drag_scalar_N(
@@ -6678,9 +6679,9 @@ def drag_scalar_N(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display multiple scalar drag widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -6693,30 +6694,30 @@ def drag_scalar_N(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         drag state change and the current drag content.
-    
+
     .. wraps::
         bool DragScalarN(
-            const char* label, 
-            ImGuiDataType data_type, 
+            const char* label,
+            ImGuiDataType data_type,
             void* p_data,
             int components,
-            float v_speed, 
+            float v_speed,
             const void* p_min = NULL,
             const void* p_max = NULL,
             const char* format = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = NULL
     if min_value is not None:
         p_min = min_value
-    cdef char* p_max = NULL 
+    cdef char* p_max = NULL
     if max_value is not None:
         p_max = max_value
     cdef char* fmt = NULL
@@ -6724,7 +6725,7 @@ def drag_scalar_N(
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.DragScalarN(
         _bytes(label),
         data_type,
@@ -6736,7 +6737,7 @@ def drag_scalar_N(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def input_text(
@@ -6774,7 +6775,7 @@ def input_text(
         buffer_length (int): length of the content buffer
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-        callback (callable): a callable that is called depending on choosen flags. 
+        callback (callable): a callable that is called depending on choosen flags.
             Callable takes an imgui._ImGuiInputTextCallbackData object as argument
             Callable should return None or integer
         user_data: Any data that the user want to use in the callback.
@@ -6793,7 +6794,7 @@ def input_text(
             void* user_data = NULL
         )
     """
-    
+
     cdef _callback_user_info _user_info = _callback_user_info()
     cdef cimgui.ImGuiInputTextCallback _callback = NULL
     cdef void *_user_data = NULL
@@ -6801,7 +6802,7 @@ def input_text(
         _callback = _ImGuiInputTextCallback
         _user_info.populate(callback, user_data)
         _user_data = <void*>_user_info
-    
+
     # todo: pymalloc
     cdef char* inout_text = <char*>malloc(buffer_length * sizeof(char))
     # todo: take special care of terminating char
@@ -6855,7 +6856,7 @@ def input_text_multiline(
         height (float): height of the textbox
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-        callback (callable): a callable that is called depending on choosen flags. 
+        callback (callable): a callable that is called depending on choosen flags.
             Callable takes an imgui._ImGuiInputTextCallbackData object as argument
             Callable should return None or integer
         user_data: Any data that the user want to use in the callback.
@@ -6875,7 +6876,7 @@ def input_text_multiline(
             void* user_data = NULL
         )
     """
-    
+
     cdef _callback_user_info _user_info = _callback_user_info()
     cdef cimgui.ImGuiInputTextCallback _callback = NULL
     cdef void *_user_data = NULL
@@ -6883,7 +6884,7 @@ def input_text_multiline(
         _callback = _ImGuiInputTextCallback
         _user_info.populate(callback, user_data)
         _user_data = <void*>_user_info
-        
+
     cdef char* inout_text = <char*>malloc(buffer_length * sizeof(char))
     # todo: take special care of terminating char
     strncpy(inout_text, _bytes(value), buffer_length)
@@ -6897,10 +6898,10 @@ def input_text_multiline(
 
     free(inout_text)
     return changed, output
-    
+
 def input_text_with_hint(
-    str label, 
-    str hint, 
+    str label,
+    str hint,
     str value,
     int buffer_length,
     cimgui.ImGuiInputTextFlags flags = 0,
@@ -6908,7 +6909,7 @@ def input_text_with_hint(
     user_data = None):
     """Display a text box, if the text is empty a hint on how to fill the box is given.
     ``buffer_length`` is the maximum allowed length of the content.
-    
+
     Args:
         label (str): Widget label
         hing (str): Hint displayed if text value empty
@@ -6916,39 +6917,39 @@ def input_text_with_hint(
         buffer_length (int): Length of the content buffer
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-        callback (callable): a callable that is called depending on choosen flags. 
+        callback (callable): a callable that is called depending on choosen flags.
             Callable takes an imgui._ImGuiInputTextCallbackData object as argument
             Callable should return None or integer
         user_data: Any data that the user want to use in the callback.
-            
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         textbox state change and the current text contents.
-    
+
     .. visual-example::
         :auto_layout:
         :width: 400
         :height: 200
-        
+
         text_val = ''
         imgui.begin("Example Text With hing")
         changed, text_val = imgui.input_text_with_hint(
-            'Email', 'your@email.com', 
+            'Email', 'your@email.com',
             text_val, 255)
         imgui.end()
-    
+
     .. wraps::
         bool InputTextWithHint(
-            const char* label, 
-            const char* hint, 
-            char* buf, 
-            size_t buf_size, 
-            ImGuiInputTextFlags flags = 0, 
-            ImGuiInputTextCallback callback = NULL, 
+            const char* label,
+            const char* hint,
+            char* buf,
+            size_t buf_size,
+            ImGuiInputTextFlags flags = 0,
+            ImGuiInputTextCallback callback = NULL,
             void* user_data = NULL
         )
     """
-    
+
     cdef _callback_user_info _user_info = _callback_user_info()
     cdef cimgui.ImGuiInputTextCallback _callback = NULL
     cdef void *_user_data = NULL
@@ -6956,17 +6957,17 @@ def input_text_with_hint(
         _callback = _ImGuiInputTextCallback
         _user_info.populate(callback, user_data)
         _user_data = <void*>_user_info
-        
+
     cdef char* inout_text = <char*>malloc(buffer_length * sizeof(char))
     strncpy(inout_text, _bytes(value), buffer_length)
-    
+
     changed = cimgui.InputTextWithHint(
         _bytes(label), _bytes(hint), inout_text, buffer_length,
         flags, _callback, _user_data
     )
-    
+
     output = _from_bytes(inout_text)
-    
+
     free(inout_text)
     return changed, output
 
@@ -7392,9 +7393,9 @@ def input_scalar(
     cimgui.ImGuiInputTextFlags flags = 0):
     """Display scalar input widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -7404,28 +7405,28 @@ def input_scalar(
         format (str): format string
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         input state change and the current input content.
-    
+
     .. wraps::
         bool InputScalar(
-            const char* label, 
-            ImGuiDataType data_type, 
-            void* p_data, 
-            const void* p_step = NULL, 
-            const void* p_step_fast = NULL, 
-            const char* format = NULL, 
+            const char* label,
+            ImGuiDataType data_type,
+            void* p_data,
+            const void* p_step = NULL,
+            const void* p_step_fast = NULL,
+            const char* format = NULL,
             ImGuiInputTextFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_step = NULL
     if step is not None:
         p_step = step
-    cdef char* p_step_fast = NULL 
+    cdef char* p_step_fast = NULL
     if step_fast is not None:
         p_step_fast = step_fast
     cdef char* fmt = NULL
@@ -7433,7 +7434,7 @@ def input_scalar(
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.InputScalar(
         _bytes(label),
         data_type,
@@ -7443,7 +7444,7 @@ def input_scalar(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def input_scalar_N(
@@ -7457,9 +7458,9 @@ def input_scalar_N(
     cimgui.ImGuiInputTextFlags flags = 0):
     """Display multiple scalar input widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -7470,29 +7471,29 @@ def input_scalar_N(
         format (str): format string
         flags: InputText flags. See:
             :ref:`list of available flags <inputtext-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         input state change and the current input content.
-    
+
     .. wraps::
         bool InputScalarN(
-            const char* label, 
-            ImGuiDataType data_type, 
+            const char* label,
+            ImGuiDataType data_type,
             void* p_data,
             int components,
-            const void* p_step = NULL, 
-            const void* p_step_fast = NULL, 
-            const char* format = NULL, 
+            const void* p_step = NULL,
+            const void* p_step_fast = NULL,
+            const char* format = NULL,
             ImGuiInputTextFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_step = NULL
     if step is not None:
         p_step = step
-    cdef char* p_step_fast = NULL 
+    cdef char* p_step_fast = NULL
     if step_fast is not None:
         p_step_fast = step_fast
     cdef char* fmt = NULL
@@ -7500,7 +7501,7 @@ def input_scalar_N(
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.InputScalarN(
         _bytes(label),
         data_type,
@@ -7511,15 +7512,15 @@ def input_scalar_N(
         fmt,
         flags
     )
-    
+
     return changed, data
-    
+
 def slider_float(
     str label,
     float value,
     float min_value,
     float max_value,
-    str format = "%.3f", 
+    str format = "%.3f",
     cimgui.ImGuiSliderFlags flags = 0,
     float power=1.0 # OBSOLETED in 1.78 (from June 2020)
 ):
@@ -7761,28 +7762,28 @@ def slider_float4(
     ), (inout_values[0], inout_values[1], inout_values[2], inout_values[3])
 
 def slider_angle(
-    str label, 
+    str label,
     float rad_value,
-    float value_degrees_min = -360.0, 
+    float value_degrees_min = -360.0,
     float value_degrees_max = 360,
-    str format = "%.0f deg", 
+    str format = "%.0f deg",
     cimgui.ImGuiSliderFlags flags = 0):
     """Display angle slider widget.
-    
+
     .. visual-example::
         :auto_layout:
         :width: 400
         :height: 130
-        
+
         radian = 3.1415/4
-        
+
         imgui.begin("Example: slider angle")
         changed, radian = imgui.slider_angle(
             "slider angle", radian,
             value_degrees_min=0.0, value_degrees_max=180.0)
         imgui.text("Changed: %s, Value: %s" % (changed, radian))
         imgui.end()
-    
+
     Args:
         labal (str): widget label
         rad_value (float): slider value in radian
@@ -7792,22 +7793,22 @@ def slider_angle(
             format string. **Warning:** highly unsafe.
         flags: SliderFlags flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-        
+
     Returns:
         tuple: a ``(changed, rad_value)`` tuple that contains indicator of
         widget state change and the current slider value in radian.
-        
-    
+
+
     .. wraps::
         bool SliderAngle(
-            const char* label, 
-            float* v_rad, float 
-            v_degrees_min = -360.0f, 
-            float v_degrees_max = +360.0f, 
-            const char* format = "%.0f deg", 
+            const char* label,
+            float* v_rad, float
+            v_degrees_min = -360.0f,
+            float v_degrees_max = +360.0f,
+            const char* format = "%.0f deg",
             ImGuiSliderFlags flags = 0
         )
-    
+
     """
     cdef float inout_r_value = rad_value
     return cimgui.SliderAngle(
@@ -8056,9 +8057,9 @@ def slider_scalar(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display scalar slider widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -8069,15 +8070,15 @@ def slider_scalar(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         slider state change and the current slider content.
-    
+
     .. wraps::
         bool SliderScalar(
-            const char* label, 
-            ImGuiDataType data_type, 
+            const char* label,
+            ImGuiDataType data_type,
             void* p_data,
             const void* p_min,
             const void* p_max,
@@ -8085,17 +8086,17 @@ def slider_scalar(
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = min_value
-    cdef char* p_max = max_value 
-    
+    cdef char* p_max = max_value
+
     cdef char* fmt = NULL
     cdef bytes fmt_data;
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.SliderScalar(
         _bytes(label),
         data_type,
@@ -8105,9 +8106,9 @@ def slider_scalar(
         fmt,
         flags
     )
-    
+
     return changed, data
-    
+
 def slider_scalar_N(
     str label,
     cimgui.ImGuiDataType data_type,
@@ -8119,9 +8120,9 @@ def slider_scalar_N(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display multiple scalar slider widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         data_type: ImGuiDataType enum, type of the given data
@@ -8133,16 +8134,16 @@ def slider_scalar_N(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         slider state change and the current slider content.
-    
+
     .. wraps::
         bool SliderScalarN(
-            const char* label, 
-            ImGuiDataType data_type, 
-            void* p_data, 
+            const char* label,
+            ImGuiDataType data_type,
+            void* p_data,
             int components,
             const void* p_min,
             const void* p_max,
@@ -8150,17 +8151,17 @@ def slider_scalar_N(
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = min_value
-    cdef char* p_max = max_value 
-    
+    cdef char* p_max = max_value
+
     cdef char* fmt = NULL
     cdef bytes fmt_data;
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.SliderScalarN(
         _bytes(label),
         data_type,
@@ -8171,7 +8172,7 @@ def slider_scalar_N(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def v_slider_float(
@@ -8304,7 +8305,7 @@ def v_slider_int(
         min_value, max_value, _bytes(format), flags
     ), inout_value
 
-    
+
 def v_slider_scalar(
     str label,
     float width,
@@ -8317,9 +8318,9 @@ def v_slider_scalar(
     cimgui.ImGuiSliderFlags flags = 0):
     """Display vertical scalar slider widget.
     Data is passed via ``bytes`` and the type is separatelly given using ``data_type``.
-    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double) 
-    like when interfacing with Numpy. 
-    
+    This is useful to work with specific types (e.g. unsigned 8bit integer, float, double)
+    like when interfacing with Numpy.
+
     Args:
         label (str): widget label
         width (float): width of the slider
@@ -8332,34 +8333,34 @@ def v_slider_scalar(
             format string. **Warning:** highly unsafe. See :any:`drag_int()`.
         flags: ImGuiSlider flags. See:
             :ref:`list of available flags <slider-flag-options>`.
-    
+
     Returns:
         tuple: a ``(changed, value)`` tuple that contains indicator of
         slider state change and the current slider content.
-    
+
     .. wraps::
         bool VSliderScalar(
-            const char* label, 
+            const char* label,
             const ImVec2& size,
-            ImGuiDataType data_type, 
-            void* p_data, 
+            ImGuiDataType data_type,
+            void* p_data,
             const void* p_min,
             const void* p_max,
             const char* format = NULL,
             ImGuiSliderFlags flags = 0
         )
     """
-    
+
     cdef char* p_data = data
     cdef char* p_min = min_value
     cdef char* p_max = max_value
-    
+
     cdef char* fmt = NULL
     cdef bytes fmt_data;
     if format is not None:
         fmt_data = _bytes(format)
         fmt = fmt_data
-        
+
     cdef changed = cimgui.VSliderScalar(
         _bytes(label),
         _cast_args_ImVec2(width, height),
@@ -8370,7 +8371,7 @@ def v_slider_scalar(
         fmt,
         flags
     )
-    
+
     return changed, data
 
 def plot_lines(
@@ -8579,7 +8580,7 @@ def progress_bar(float fraction, size = (-FLOAT_MIN,0), str overlay = ""):
     .. wraps::
         void ProgressBar(
             float fraction,
-            const ImVec2& size_arg = ImVec2(-FLT_MIN, 0), 
+            const ImVec2& size_arg = ImVec2(-FLT_MIN, 0),
             const char* overlay = NULL
         )
 
@@ -8646,9 +8647,9 @@ def is_item_active():
 
 
 def is_item_clicked(cimgui.ImGuiMouseButton mouse_button = 0):
-    """ Was the last item hovered and mouse clicked on? 
+    """ Was the last item hovered and mouse clicked on?
     Button or node that was just being clicked on.
-    
+
     Args:
         mouse_button: ImGuiMouseButton
 
@@ -8674,12 +8675,12 @@ def is_item_visible():
     return cimgui.IsItemVisible()
 
 def is_item_edited():
-    """Did the last item modify its underlying value this frame? or was pressed? 
+    """Did the last item modify its underlying value this frame? or was pressed?
     This is generally the same as the "bool" return value of many widgets.
-    
+
     Returns:
         bool: True if item is edited, otherwise False.
-    
+
     .. wraps::
         bool IsItemEdited()
     """
@@ -8687,35 +8688,35 @@ def is_item_edited():
 
 def is_item_activated():
     """Was the last item just made active (item was previously inactive)?
-    
+
     Returns:
         bool: True if item was just made active
-    
+
     .. wraps::
         bool IsItemActivated()
     """
     return cimgui.IsItemActivated()
 
 def is_item_deactivated():
-    """Was the last item just made inactive (item was previously active)? 
+    """Was the last item just made inactive (item was previously active)?
     Useful for Undo/Redo patterns with widgets that requires continuous editing.
-        
+
     Results:
         bool: True if item just made inactive
-        
+
     .. wraps:
         bool IsItemDeactivated()
     """
     return cimgui.IsItemDeactivated
 
 def is_item_deactivated_after_edit():
-    """Was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved). 
-    Useful for Undo/Redo patterns with widgets that requires continuous editing. 
+    """Was the last item just made inactive and made a value change when it was active? (e.g. Slider/Drag moved).
+    Useful for Undo/Redo patterns with widgets that requires continuous editing.
     Note that you may get false positives (some widgets such as Combo()/ListBox()/Selectable() will return true even when clicking an already selected item).
-    
+
     Results:
         bool: True if item just made inactive after an edition
-    
+
     .. wraps::
         bool IsItemDeactivatedAfterEdit()
     """
@@ -8723,7 +8724,7 @@ def is_item_deactivated_after_edit():
 
 def is_item_toggled_open():
     """Was the last item open state toggled? set by TreeNode().
-    
+
     .. wraps::
         bool IsItemToggledOpen()
     """
@@ -8812,15 +8813,15 @@ def set_item_allow_overlap():
     cimgui.SetItemAllowOverlap()
 
 def get_main_viewport():
-    """Currently represents the Platform Window created by the application which is hosting 
+    """Currently represents the Platform Window created by the application which is hosting
     our Dear ImGui windows.
-    
-    In the future we will extend this concept further to also represent Platform Monitor 
+
+    In the future we will extend this concept further to also represent Platform Monitor
     and support a "no main platform window" operation mode.
-    
+
     Returns:
         _ImGuiViewport: Viewport
-    
+
     .. wraps::
         ImGuiViewport* GetMainViewport()
     """
@@ -8894,26 +8895,26 @@ def get_time():
     """
     return cimgui.GetTime()
 
-    
+
 def get_background_draw_list():
-    """This draw list will be the first rendering one. 
+    """This draw list will be the first rendering one.
     Useful to quickly draw shapes/text behind dear imgui contents.
-    
+
     Returns:
         DrawList*
-        
+
     .. wraps::
         ImDrawList* GetBackgroundDrawList()
     """
     return _DrawList.from_ptr(cimgui.GetBackgroundDrawList())
-    
+
 def get_foreground_draw_list():
-    """This draw list will be the last rendered one. 
+    """This draw list will be the last rendered one.
     Useful to quickly draw shapes/text over dear imgui contents.
-    
+
     Returns:
         DrawList*
-        
+
     .. wraps::
         ImDrawList* GetForegroundDrawList()
     """
@@ -9096,73 +9097,73 @@ def set_mouse_cursor(cimgui.ImGuiMouseCursor mouse_cursor_type):
     return cimgui.SetMouseCursor(mouse_cursor_type)
 
 def capture_mouse_from_app(bool want_capture_mouse_value = True):
-    """Attention: misleading name! 
-    Manually override io.WantCaptureMouse flag next frame 
-    (said flag is entirely left for your application to handle). 
-    
-    This is equivalent to setting "io.WantCaptureMouse = want_capture_mouse_value;" 
+    """Attention: misleading name!
+    Manually override io.WantCaptureMouse flag next frame
+    (said flag is entirely left for your application to handle).
+
+    This is equivalent to setting "io.WantCaptureMouse = want_capture_mouse_value;"
     after the next NewFrame() call.
-    
+
     .. wraps::
         void CaptureMouseFromApp(bool want_capture_mouse_value = true)
     """
     cimgui.CaptureMouseFromApp(want_capture_mouse_value)
-    
+
 def get_clipboard_text():
-    """Also see the ``log_to_clipboard()`` function to capture GUI into clipboard, 
+    """Also see the ``log_to_clipboard()`` function to capture GUI into clipboard,
     or easily output text data to the clipboard.
-    
+
     Returns:
         str: Text content of the clipboard
-    
+
     .. wraps::
         const char* GetClipboardText()
     """
     return _from_bytes(cimgui.GetClipboardText())
-    
+
 def load_ini_settings_from_disk(str ini_file_name):
-    """Call after ``create_context()`` and before the first call to ``new_frame()``. 
+    """Call after ``create_context()`` and before the first call to ``new_frame()``.
     ``new_frame()`` automatically calls ``load_ini_settings_from_disk(io.ini_file_name)``.
-    
+
     Args:
         ini_file_name (str): Filename to load settings from.
-    
+
     .. wraps::
         void LoadIniSettingsFromDisk(const char* ini_filename)
     """
     cimgui.LoadIniSettingsFromDisk(_bytes(ini_file_name))
 
 def load_ini_settings_from_memory(str ini_data):
-    """Call after ``create_context()`` and before the first call to ``new_frame()`` 
+    """Call after ``create_context()`` and before the first call to ``new_frame()``
     to provide .ini data from your own data source.
-    
+
     .. wraps::
         void LoadIniSettingsFromMemory(const char* ini_data, size_t ini_size=0)
     """
     #cdef size_t ini_size = len(ini_data)
     cimgui.LoadIniSettingsFromMemory(_bytes(ini_data), 0)
-    
+
 def save_ini_settings_to_disk(str ini_file_name):
-    """This is automatically called (if ``io.ini_file_name`` is not empty) 
-    a few seconds after any modification that should be reflected in the .ini file 
+    """This is automatically called (if ``io.ini_file_name`` is not empty)
+    a few seconds after any modification that should be reflected in the .ini file
     (and also by ``destroy_context``).
-    
+
     Args:
         ini_file_name (str): Filename to save settings to.
-    
+
     .. wraps::
         void SaveIniSettingsToDisk(const char* ini_filename)
     """
     cimgui.SaveIniSettingsToDisk(_bytes(ini_file_name))
-    
+
 def save_ini_settings_to_memory():
-    """Return a string with the .ini data which you can save by your own mean. 
-    Call when ``io.want_save_ini_settings`` is set, then save data by your own mean 
-    and clear ``io.want_save_ini_settings``. 
-    
+    """Return a string with the .ini data which you can save by your own mean.
+    Call when ``io.want_save_ini_settings`` is set, then save data by your own mean
+    and clear ``io.want_save_ini_settings``.
+
     Returns:
         str: Settings data
-    
+
     .. wraps::
        const char* SaveIniSettingsToMemory(size_t* out_ini_size = NULL)
     """
@@ -9170,10 +9171,10 @@ def save_ini_settings_to_memory():
 
 def set_clipboard_text(str text):
     """Set the clipboard content
-    
+
     Args:
         text (str): Text to copy in clipboard
-    
+
     .. wraps:
         void SetClipboardText(const char* text)
     """
@@ -9193,16 +9194,16 @@ def set_clipboard_text(str text):
 #        void SetScrollHere(float center_y_ratio = 0.5f)
 #    """
 #    return cimgui.SetScrollHere(center_y_ratio)
-    
+
 def set_scroll_here_x(float center_x_ratio = 0.5):
     """Set scroll here X.
 
-    Adjust scrolling amount to make current cursor position visible. 
+    Adjust scrolling amount to make current cursor position visible.
     center_x_ratio =
-        0.0: left, 
-        0.5: center, 
-        1.0: right. 
-        
+        0.0: left,
+        0.5: center,
+        1.0: right.
+
     When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
 
     Args:
@@ -9212,16 +9213,16 @@ def set_scroll_here_x(float center_x_ratio = 0.5):
         void SetScrollHereX(float center_x_ratio = 0.5f)
     """
     return cimgui.SetScrollHereX(center_x_ratio)
-    
+
 def set_scroll_here_y(float center_y_ratio = 0.5):
     """Set scroll here Y.
 
-    Adjust scrolling amount to make current cursor position visible. 
+    Adjust scrolling amount to make current cursor position visible.
     center_y_ratio =
-        0.0: top, 
-        0.5: center, 
-        1.0: bottom. 
-        
+        0.0: top,
+        0.5: center,
+        1.0: bottom.
+
     When using to make a "default/current item" visible, consider using SetItemDefaultFocus() instead.
 
     Args:
@@ -9236,9 +9237,9 @@ def set_scroll_here_y(float center_y_ratio = 0.5):
 def set_scroll_from_pos_x(float local_x, float center_x_ratio = 0.5):
     """Set scroll from position X
 
-    Adjust scrolling amount to make given position visible. 
+    Adjust scrolling amount to make given position visible.
     Generally GetCursorStartPos() + offset to compute a valid position.
-    
+
     Args:
         float local_x
         float center_x_ratio = 0.5f
@@ -9252,9 +9253,9 @@ def set_scroll_from_pos_x(float local_x, float center_x_ratio = 0.5):
 def set_scroll_from_pos_y(float local_y, float center_y_ratio = 0.5):
     """Set scroll from position Y
 
-    Adjust scrolling amount to make given position visible. 
+    Adjust scrolling amount to make given position visible.
     Generally GetCursorStartPos() + offset to compute a valid position.
-    
+
     Args:
         float local_y
         float center_y_ratio = 0.5f
@@ -9353,16 +9354,16 @@ cpdef calc_text_size(str text, bool hide_text_after_double_hash = False, float w
             wrap_width
         )
     )
-    
+
 def color_convert_u32_to_float4(cimgui.ImU32 in_):
     """Convert an unsigned int 32 to 4 component r, g, b, a
-    
+
     Args:
         in_ (ImU32): Color in unsigned int 32 format
-    
+
     Return:
         tuple: r, g, b, a components of the color
-    
+
     .. wraps::
         ImVec4 ColorConvertU32ToFloat4(ImU32 in)
     """
@@ -9370,13 +9371,13 @@ def color_convert_u32_to_float4(cimgui.ImU32 in_):
 
 def color_convert_float4_to_u32(float r, float g, float b, float a):
     """Convert a set of r, g, b, a floats to unsigned int 32 color
-    
+
     Args:
         r, g, b, a (float): Components of the color
-    
+
     Returns:
         ImU32: Unsigned int 32 color format
-    
+
     .. wraps::
         ImU32 ColorConvertFloat4ToU32(const ImVec4& in)
     """
@@ -9385,13 +9386,13 @@ def color_convert_float4_to_u32(float r, float g, float b, float a):
 
 def color_convert_rgb_to_hsv(float r, float g, float b):
     """Convert color from RGB space to HSV space
-    
+
     Args:
         r, g, b (float): RGB color format
-    
+
     Returns:
         tuple: h, s, v HSV color format
-    
+
     .. wraps::
         void ColorConvertRGBtoHSV(float r, float g, float b, float& out_h, float& out_s, float& out_v)
     """
@@ -9399,16 +9400,16 @@ def color_convert_rgb_to_hsv(float r, float g, float b):
     out_h = out_s = out_v = 0
     cimgui.ColorConvertRGBtoHSV(r,g,b,out_h,out_s,out_v)
     return out_h, out_s, out_v
-    
+
 def color_convert_hsv_to_rgb(float h, float s, float v):
     """Convert color from HSV space to RGB space
-    
+
     Args:
         h, s, v (float): HSV color format
-    
+
     Returns:
         tuple: r, g, b RGB color format
-    
+
     .. wraps::
         void ColorConvertHSVtoRGB(float h, float s, float v, float& out_r, float& out_g, float& out_b)
     """
@@ -9642,27 +9643,27 @@ cpdef pop_item_width():
     cimgui.PopItemWidth()
 
 cpdef set_next_item_width(float item_width):
-    """Set width of the _next_ common large "item+label" widget. 
+    """Set width of the _next_ common large "item+label" widget.
     * ``>0.0`` - width in pixels
     * ``<0.0`` - align xx pixels to the right of window
       (so -FLOAT_MIN always align width to the right side)
-      
+
     Helper to avoid using ``push_item_width()``/``pop_item_width()`` for single items.
-    
+
     Args:
         item_width (float): width of the component
-    
+
     .. visual-example::
         :auto_layout:
         :width: 200
         :height: 200
-        
+
         imgui.begin("Exemple: Next item width")
         imgui.set_next_item_width(imgui.get_window_width() * 0.33)
         imgui.slider_float('Slider 1', 10.2, 0.0, 20.0, '%.2f', 1.0)
         imgui.slider_float('Slider 2', 10.2, 0.0, 20.0, '%.2f', 1.0)
         imgui.end()
-    
+
     .. wraps::
         void SetNextItemWidth(float item_width)
     """
@@ -9927,7 +9928,7 @@ def unindent(float width=0.0):
 def columns(int count=1, str identifier=None, bool border=True):
     """Setup number of columns. Use an identifier to distinguish multiple
     column sets. close with ``columns(1)``.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     .. visual-example::
@@ -9990,7 +9991,7 @@ def next_column():
     """Move to the next column drawing.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     .. wraps::
@@ -10003,7 +10004,7 @@ def get_column_index():
     """Returns the current column index.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Returns:
@@ -10022,7 +10023,7 @@ def get_column_offset(int column_index=-1):
     unless you call this method.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Args:
@@ -10042,7 +10043,7 @@ def set_column_offset(int column_index, float offset_x):
     contents region). Pass -1 to use current column.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Args:
@@ -10059,7 +10060,7 @@ def get_column_width(int column_index=-1):
     """Return the column width.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Args:
@@ -10076,7 +10077,7 @@ def set_column_width(int column_index, float width):
     contents region). Pass -1 to use current column.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Args:
@@ -10093,7 +10094,7 @@ def get_columns_count():
     """Get count of the columns in the current table.
 
     For a complete example see :func:`columns()`.
-    
+
     Legacy Columns API (2020: prefer using Tables!)
 
     Returns:
@@ -10106,75 +10107,75 @@ def get_columns_count():
 
 def begin_tab_bar(str identifier, cimgui.ImGuiTabBarFlags flags = 0):
     """Create and append into a TabBar
-    
+
     Args:
         identifier(str): String identifier of the tab window
         flags: ImGuiTabBarFlags flags. See:
             :ref:`list of available flags <tabbar-flag-options>`.
-    
+
     Returns:
         bool: True if the Tab Bar is open
-        
+
     .. wraps::
         bool BeginTabBar(const char* str_id, ImGuiTabBarFlags flags = 0)
-    
+
     """
     return cimgui.BeginTabBar(_bytes(identifier), flags)
-    
+
 def end_tab_bar():
     """Only call end_tab_bar() if begin_tab_bar() returns true!
-    
+
     .. wraps::
         void EndTabBar()
     """
     cimgui.EndTabBar()
-    
+
 def begin_tab_item(str label, opened = None, cimgui.ImGuiTabItemFlags flags = 0):
-    """Create a Tab. 
-    
+    """Create a Tab.
+
     Args:
         label (str): Label of the tab item
         removable (bool): If True, the tab item can be removed
         flags: ImGuiTabItemFlags flags. See:
             :ref:`list of available flags <tabitem-flag-options>`.
-        
+
     Returns:
         tuple: ``(slected, opened)`` tuple of bools. If tab item is selected
         ``selected==True``. The value of ``opened`` is always True for
         non-removable and open tab items but changes state to False on close
         button click for removable tab items.
-        
+
     .. visual-example::
         :auto_layout:
         :width: 300
-        
+
         opened_state = True
-        
+
         #...
-        
+
         imgui.begin("Example Tab Bar")
         if imgui.begin_tab_bar("MyTabBar"):
-            
+
             if imgui.begin_tab_item("Item 1")[0]:
                 imgui.text("Here is the tab content!")
                 imgui.end_tab_item()
-                
+
             if imgui.begin_tab_item("Item 2")[0]:
                 imgui.text("Another content...")
                 imgui.end_tab_item()
-                
+
             selected, opened_state = imgui.begin_tab_item("Item 3", opened=opened_state)
             if selected:
                 imgui.text("Hello Saylor!")
                 imgui.end_tab_item()
-                
+
             imgui.end_tab_bar()
         imgui.end()
-    
+
     .. wraps::
         bool BeginTabItem(
-            const char* label, 
-            bool* p_open = NULL, 
+            const char* label,
+            bool* p_open = NULL,
             ImGuiTabItemFlags flags = 0
         )
     """
@@ -10183,74 +10184,74 @@ def begin_tab_item(str label, opened = None, cimgui.ImGuiTabItemFlags flags = 0)
 
 def end_tab_item():
     """Only call end_tab_item() if begin_tab_item() returns true!
-    
+
     .. wraps::
         void EndTabItem()
     """
     cimgui.EndTabItem()
 
 def tab_item_button(str label, cimgui.ImGuiTabItemFlags flags = 0):
-    """Create a Tab behaving like a button. 
+    """Create a Tab behaving like a button.
     Cannot be selected in the tab bar.
-    
+
     Args:
         label (str): Label of the button
         flags: ImGuiTabItemFlags flags. See:
             :ref:`list of available flags <tabitem-flag-options>`.
-    
+
     Returns:
         (bool): Return true when clicked.
-    
+
     .. visual-example:
         :auto_layout:
         :width: 300
-        
+
         imgui.begin("Example Tab Bar")
         if imgui.begin_tab_bar("MyTabBar"):
-            
+
             if imgui.begin_tab_item("Item 1")[0]:
                 imgui.text("Here is the tab content!")
                 imgui.end_tab_item()
-                
+
             if imgui.tab_item_button("Click me!"):
                 print('Clicked!')
-                
+
             imgui.end_tab_bar()
         imgui.end()
-    
+
     .. wraps::
         bool TabItemButton(const char* label, ImGuiTabItemFlags flags = 0)
     """
     return cimgui.TabItemButton(_bytes(label), flags)
-    
+
 def set_tab_item_closed(str tab_or_docked_window_label):
-    """Notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars). 
-    For tab-bar: call after BeginTabBar() and before Tab submissions. 
+    """Notify TabBar or Docking system of a closed tab/window ahead (useful to reduce visual flicker on reorderable tab bars).
+    For tab-bar: call after BeginTabBar() and before Tab submissions.
     Otherwise call with a window name.
-    
+
     Args:
         tab_or_docked_window_label (str): Label of the targeted tab or docked window
-    
+
     .. visual-example:
         :auto_layout:
         :width: 300
-        
+
         imgui.begin("Example Tab Bar")
         if imgui.begin_tab_bar("MyTabBar"):
-            
+
             if imgui.begin_tab_item("Item 1")[0]:
                 imgui.text("Here is the tab content!")
                 imgui.end_tab_item()
-                
+
             if imgui.begin_tab_item("Item 2")[0]:
                 imgui.text("This item won't whow !")
                 imgui.end_tab_item()
-                
+
             imgui.set_tab_item_closed("Item 2")
-                
+
             imgui.end_tab_bar()
         imgui.end()
-    
+
     .. wraps:
         void SetTabItemClosed(const char* tab_or_docked_window_label)
     """
@@ -10386,11 +10387,11 @@ def end_drag_drop_target():
 
 
 def get_drag_drop_payload():
-    """Peek directly into the current payload from anywhere. 
-    May return NULL. 
-    
+    """Peek directly into the current payload from anywhere.
+    May return NULL.
+
     .. todo:: Map ImGuiPayload::IsDataType() to test for the payload type.
-    
+
     .. wraps::
         const ImGuiPayload* GetDragDropPayload()
     """
@@ -10407,41 +10408,41 @@ def push_clip_rect(
         float clip_rect_max_y,
         bool intersect_with_current_clip_rect = False
     ):
-    """Push the clip region, i.e. the area of the screen to be rendered,on the stack. 
-    If ``intersect_with_current_clip_rect`` is ``True``, the intersection between pushed 
-    clip region and previous one is added on the stack. 
+    """Push the clip region, i.e. the area of the screen to be rendered,on the stack.
+    If ``intersect_with_current_clip_rect`` is ``True``, the intersection between pushed
+    clip region and previous one is added on the stack.
     See: :func:`pop_clip_rect()`
-    
+
     Args:
         clip_rect_min_x, clip_rect_min_y (float): Position of the minimum point of the rectangle
         clip_rect_max_x, clip_rect_max_y (float): Position of the maximum point of the rectangle
         intersect_with_current_clip_rect (bool): If True, intersection with current clip region is pushed on stack.
-    
+
     .. visual-example::
         :auto_layout:
         :width: 150
         :height: 150
 
         imgui.begin("Example Cliprect")
-        
+
         winpos = imgui.get_window_position()
         imgui.push_clip_rect(0+winpos.x,0+winpos.y,100+winpos.x,100+winpos.y)
         imgui.push_clip_rect(50+winpos.x,50+winpos.y,100+winpos.x,100+winpos.y, True)
-        
+
         imgui.text('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
         imgui.text('Vivamus mattis velit ac ex auctor gravida.')
         imgui.text('Quisque varius erat finibus porta interdum.')
         imgui.text('Nam neque magna, dapibus placerat urna eget, facilisis malesuada ipsum.')
-        
+
         imgui.pop_clip_rect()
         imgui.pop_clip_rect()
-        
+
         imgui.end()
-    
+
     .. wraps::
         void PushClipRect(
-            const ImVec2& clip_rect_min, 
-            const ImVec2& clip_rect_max, 
+            const ImVec2& clip_rect_min,
+            const ImVec2& clip_rect_max,
             bool intersect_with_current_clip_rect
         )
     """
@@ -10450,10 +10451,10 @@ def push_clip_rect(
         _cast_args_ImVec2(clip_rect_max_x, clip_rect_max_y),
         intersect_with_current_clip_rect
     )
-    
+
 def pop_clip_rect():
     """Pop the last clip region from the stack. See: :func:`push_clip_rect()`.
-    
+
     .. wraps::
         void PopClipRect()
     """
@@ -10654,7 +10655,7 @@ def destroy_context(_ImGuiContext ctx = None):
     if ctx and ctx._ptr != NULL:
         cimgui.DestroyContext(ctx._ptr)
         ctx._ptr = NULL
-        
+
         # Update submodules:
         internal.UpdateImGuiContext(NULL)
     else:
@@ -10681,7 +10682,7 @@ def set_current_context(_ImGuiContext ctx):
                 ImGuiContext *ctx);
     """
     cimgui.SetCurrentContext(ctx._ptr)
-    
+
     # Update submodules:
     internal.UpdateImGuiContext(ctx._ptr)
 

--- a/imgui/plot.pyx
+++ b/imgui/plot.pyx
@@ -1,0 +1,1942 @@
+# distutils: language = c++
+# distutils: sources = imgui-cpp/imgui.cpp imgui-cpp/imgui_draw.cpp imgui-cpp/imgui_demo.cpp imgui-cpp/imgui_widgets.cpp imgui-cpp/imgui_tables.cpp config-cpp/py_imconfig.cpp implot-cpp/implot.cpp implot-cpp/implot_items.cpp implot-cpp/implot_demo.cpp
+# distutils: include_dirs = imgui-cpp ansifeed-cpp implot-cpp
+# cython: embedsignature=True
+
+import cython
+from cython.operator cimport dereference as deref
+from cpython cimport array
+import warnings
+
+from libcpp cimport bool
+from libc.stdlib cimport malloc, free
+
+cimport cimplot
+cimport cimgui
+cimport core
+cimport enums
+
+from cpython.version cimport PY_MAJOR_VERSION
+
+# ImPlot version string
+IMPLOT_VERSION = "0.9 WIP"
+# Indicates variable should deduced automatically.
+IMPLOT_AUTO = -1
+# Special color used to indicate that a color should be deduced automatically.
+IMPLOT_AUTO_COL = (0, 0, 0, -1)
+
+COLOR_COUNT = cimplot.ImPlotCol_COUNT
+
+# Options for plots
+PLOT_FLAGS_NONE = cimplot.ImPlotFlags_None
+PLOT_FLAGS_NO_TITLE = cimplot.ImPlotFlags_NoTitle
+PLOT_FLAGS_NO_LEGEND = cimplot.ImPlotFlags_NoLegend
+PLOT_FLAGS_NO_MENUS = cimplot.ImPlotFlags_NoMenus
+PLOT_FLAGS_NO_BOX_SELECT = cimplot.ImPlotFlags_NoBoxSelect
+PLOT_FLAGS_NO_MOUSE_POS = cimplot.ImPlotFlags_NoMousePos
+PLOT_FLAGS_NO_HIGHLIGHT = cimplot.ImPlotFlags_NoHighlight
+PLOT_FLAGS_NO_CHILD = cimplot.ImPlotFlags_NoChild
+PLOT_FLAGS_EQUAL = cimplot.ImPlotFlags_Equal
+PLOT_FLAGS_YAXIS2 = cimplot.ImPlotFlags_YAxis2
+PLOT_FLAGS_YAXIS3 = cimplot.ImPlotFlags_YAxis3
+PLOT_FLAGS_QUERY = cimplot.ImPlotFlags_Query
+PLOT_FLAGS_CROSSHAIRS = cimplot.ImPlotFlags_Crosshairs
+PLOT_FLAGS_ANTI_ALIASED = cimplot.ImPlotFlags_AntiAliased
+PLOT_FLAGS_CANVAS_ONLY = cimplot.ImPlotFlags_CanvasOnly
+
+# Options for plot axes (X and Y)
+AXIS_FLAGS_NONE = cimplot.ImPlotAxisFlags_None
+AXIS_FLAGS_NO_LABEL = cimplot.ImPlotAxisFlags_NoLabel
+AXIS_FLAGS_NO_GRID_LINES = cimplot.ImPlotAxisFlags_NoGridLines
+AXIS_FLAGS_NO_TICK_MARKS = cimplot.ImPlotAxisFlags_NoTickMarks
+AXIS_FLAGS_NO_TICK_LABELS = cimplot.ImPlotAxisFlags_NoTickLabels
+AXIS_FLAGS_LOD_SCALE = cimplot.ImPlotAxisFlags_LogScale
+AXIS_FLAGS_TIME = cimplot.ImPlotAxisFlags_Time
+AXIS_FLAGS_INVERT = cimplot.ImPlotAxisFlags_Invert
+AXIS_FLAGS_AUTO_FIT = cimplot.ImPlotAxisFlags_AutoFit
+AXIS_FLAGS_LOCK_MIN = cimplot.ImPlotAxisFlags_LockMin
+AXIS_FLAGS_LOCK_MAX = cimplot.ImPlotAxisFlags_LockMax
+AXIS_FLAGS_LOCK = cimplot.ImPlotAxisFlags_Lock
+AXIS_FLAGS_NO_DECORATIONS = cimplot.ImPlotAxisFlags_NoDecorations
+
+
+##########################################################################################3
+
+include "imgui/common.pyx"
+
+
+cdef class _ImPlotContext(object):
+    cdef cimplot.ImPlotContext* _ptr
+
+    @staticmethod
+    cdef from_ptr(cimplot.ImPlotContext* ptr):
+        if ptr == NULL:
+            return None
+
+        instance = _ImPlotContext()
+        instance._ptr = ptr
+        return instance
+
+    def __eq__(_ImPlotContext self, _ImPlotContext other):
+        return other._ptr == self._ptr
+
+
+cdef class _Colors(object):
+    cdef PlotStyle _style
+
+    def __cinit__(self):
+        self._style = None
+
+    def __init__(self, PlotStyle style):
+        self._style = style
+
+    cdef inline _check_color(self, cimplot.ImPlotCol variable):
+        if not (0 <= variable < cimplot.ImPlotCol_COUNT):
+            raise ValueError("Unknown style variable: {}".format(variable))
+
+    def __getitem__(self, cimplot.ImPlotCol variable):
+        self._check_color(variable)
+        self._style._check_ptr()
+        cdef int ix = variable
+        return _cast_ImVec4_tuple(self._style._ptr.Colors[ix])
+
+    def __setitem__(self, cimplot.ImPlotCol variable, value):
+        self._check_color(variable)
+        self._style._check_ptr()
+        cdef int ix = variable
+        self._style._ptr.Colors[ix] = _cast_tuple_ImVec4(value)
+
+
+cdef class PlotStyle(object):
+    """
+    Container for ImPlot style information
+
+    """
+    cdef cimplot.ImPlotStyle* _ptr
+    cdef bool _owner
+    cdef _Colors _colors
+
+    def __cinit__(self):
+        self._ptr = NULL
+        self._owner = False
+        self._colors = None
+
+    def __dealloc__(self):
+        if self._owner:
+            del self._ptr
+            self._ptr = NULL
+
+
+    cdef inline _check_ptr(self):
+        if self._ptr is NULL:
+            raise RuntimeError(
+                "Improperly initialized, use imgui.plot.get_style() or "
+                "PlotStyle.created() to obtain style classes"
+            )
+
+    def __eq__(PlotStyle self, PlotStyle other):
+        return other._ptr == self._ptr
+
+    @staticmethod
+    def create():
+        return PlotStyle._create()
+
+    @staticmethod
+    cdef PlotStyle from_ref(cimplot.ImPlotStyle& ref):
+        cdef PlotStyle instance = PlotStyle()
+        instance._ptr = &ref
+        instance._colors = _Colors(instance)
+        return instance
+
+    @staticmethod
+    cdef PlotStyle _create():
+        cdef cimplot.ImPlotStyle* _ptr = new cimplot.ImPlotStyle()
+        cdef PlotStyle instance = PlotStyle.from_ref(deref(_ptr))
+        instance._owner = True
+        instance._colors = _Colors(instance)
+        return instance
+    ## float LineWeight
+
+    @property
+    def line_weight(self):
+        self._check_ptr()
+        return self._ptr.LineWeight
+
+    @line_weight.setter
+    def line_weight(self, float value):
+        self._check_ptr()
+        self._ptr.LineWeight = value
+
+    ## int Marker
+
+    @property
+    def marker(self):
+        self._check_ptr()
+        return self._ptr.Marker
+
+    @marker.setter
+    def marker(self, int value):
+        self._check_ptr()
+        self._ptr.Marker = value
+
+    ## float MarkerSize
+
+    @property
+    def marker_size(self):
+        self._check_ptr()
+        return self._ptr.MarkerSize
+
+    @marker_size.setter
+    def marker_size(self, float value):
+        self._check_ptr()
+        self._ptr.MarkerSize = value
+
+    ## float MarkerWeight
+
+    @property
+    def marker_weight(self):
+        self._check_ptr()
+        return self._ptr.MarkerWeight
+
+    @marker_weight.setter
+    def marker_weight(self, float value):
+        self._check_ptr()
+        self._ptr.MarkerWeight = value
+
+    ## float FillAlpha
+
+    @property
+    def fill_alpha(self):
+        self._check_ptr()
+        return self._ptr.FillAlpha
+
+    @fill_alpha.setter
+    def fill_alpha(self, float value):
+        self._check_ptr()
+        self._ptr.FillAlpha = value
+
+    ## float ErrorBarSize
+
+    @property
+    def error_bar_size(self):
+        self._check_ptr()
+        return self._ptr.ErrorBarSize
+
+    @error_bar_size.setter
+    def error_bar_size(self, float value):
+        self._check_ptr()
+        self._ptr.ErrorBarSize = value
+
+    ## float ErrorBarWeight
+
+    @property
+    def error_bar_weight(self):
+        self._check_ptr()
+        return self._ptr.ErrorBarWeight
+
+    @error_bar_weight.setter
+    def error_bar_weight(self, float value):
+        self._check_ptr()
+        self._ptr.ErrorBarWeight = value
+
+    ## float DigitalBitHeight
+
+    @property
+    def digital_bit_height(self):
+        self._check_ptr()
+        return self._ptr.DigitalBitHeight
+
+    @digital_bit_height.setter
+    def digital_bit_height(self, float value):
+        self._check_ptr()
+        self._ptr.DigitalBitHeight = value
+
+    ## float DigitalBitGap
+
+    @property
+    def digital_bit_gap(self):
+        self._check_ptr()
+        return self._ptr.DigitalBitGap
+
+    @digital_bit_gap.setter
+    def digital_bit_gap(self, float value):
+        self._check_ptr()
+        self._ptr.DigitalBitGap = value
+
+    ## float PlotBorderSize
+
+    @property
+    def plot_border_size(self):
+        self._check_ptr()
+        return self._ptr.PlotBorderSize
+
+    @plot_border_size.setter
+    def plot_border_size(self, float value):
+        self._check_ptr()
+        self._ptr.PlotBorderSize = value
+
+    ## float MinorAlpha
+
+    @property
+    def minor_alpha(self):
+        self._check_ptr()
+        return self._ptr.MinorAlpha
+
+    @minor_alpha.setter
+    def minor_alpha(self, float value):
+        self._check_ptr()
+        self._ptr.MinorAlpha = value
+
+    ## ImVec2 MajorTickLen
+
+    @property
+    def major_tick_len(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.MajorTickLen)
+
+    @major_tick_len.setter
+    def major_tick_len(self, value):
+        self._check_ptr()
+        self._ptr.MajorTickLen = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 MinorTickLen
+
+    @property
+    def minor_tick_len(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.MinorTickLen)
+
+    @minor_tick_len.setter
+    def minor_tick_len(self, value):
+        self._check_ptr()
+        self._ptr.MinorTickLen = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 MajorTickSize
+
+    @property
+    def major_tick_size(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.MajorTickSize)
+
+    @major_tick_size.setter
+    def major_tick_size(self, value):
+        self._check_ptr()
+        self._ptr.MajorTickSize = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 MinorTickSize
+
+    @property
+    def minor_tick_size(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.MinorTickSize)
+
+    @minor_tick_size.setter
+    def minor_tick_size(self, value):
+        self._check_ptr()
+        self._ptr.MinorTickSize = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 MajorGridSize
+
+    @property
+    def major_grid_size(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.MajorGridSize)
+
+    @major_grid_size.setter
+    def major_grid_size(self, value):
+        self._check_ptr()
+        self._ptr.MajorGridSize = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 MinorGridSize
+
+    @property
+    def minor_grid_size(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.MinorGridSize)
+
+    @minor_grid_size.setter
+    def minor_grid_size(self, value):
+        self._check_ptr()
+        self._ptr.MinorGridSize = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 PlotPadding
+
+    @property
+    def plot_padding(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.PlotPadding)
+
+    @plot_padding.setter
+    def plot_padding(self, value):
+        self._check_ptr()
+        self._ptr.PlotPadding = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 LabelPadding
+
+    @property
+    def label_padding(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.LabelPadding)
+
+    @label_padding.setter
+    def label_padding(self, value):
+        self._check_ptr()
+        self._ptr.LabelPadding = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 LegendPadding
+
+    @property
+    def legend_padding(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.LegendPadding)
+
+    @legend_padding.setter
+    def legend_padding(self, value):
+        self._check_ptr()
+        self._ptr.LegendPadding = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 LegendInnerPadding
+
+    @property
+    def legend_inner_padding(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.LegendInnerPadding)
+
+    @legend_inner_padding.setter
+    def legend_inner_padding(self, value):
+        self._check_ptr()
+        self._ptr.LegendInnerPadding = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 LegendSpacing
+
+    @property
+    def legend_spacing(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.LegendSpacing)
+
+    @legend_spacing.setter
+    def legend_spacing(self, value):
+        self._check_ptr()
+        self._ptr.LegendSpacing = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 MousePosPadding
+
+    @property
+    def mouse_pos_padding(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.MousePosPadding)
+
+    @mouse_pos_padding.setter
+    def mouse_pos_padding(self, value):
+        self._check_ptr()
+        self._ptr.MousePosPadding = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 AnnotationPadding
+
+    @property
+    def annotation_padding(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.AnnotationPadding)
+
+    @annotation_padding.setter
+    def annotation_padding(self, value):
+        self._check_ptr()
+        self._ptr.AnnotationPadding = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 FitPadding
+
+    @property
+    def fit_padding(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.FitPadding)
+
+    @fit_padding.setter
+    def fit_padding(self, value):
+        self._check_ptr()
+        self._ptr.FitPadding = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 PlotDefaultSize
+
+    @property
+    def plot_default_size(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.PlotDefaultSize)
+
+    @plot_default_size.setter
+    def plot_default_size(self, value):
+        self._check_ptr()
+        self._ptr.PlotDefaultSize = _cast_tuple_ImVec2(value)
+
+    ## ImVec2 PlotMinSize
+
+    @property
+    def plot_min_size(self):
+        self._check_ptr()
+        return _cast_ImVec2_tuple(self._ptr.PlotMinSize)
+
+    @plot_min_size.setter
+    def plot_min_size(self, value):
+        self._check_ptr()
+        self._ptr.PlotMinSize = _cast_tuple_ImVec2(value)
+
+    ## ImVec4 *Colors
+
+
+    def color(self, cimplot.ImPlotCol variable):
+        if not (0 <= variable < cimplot.ImPlotCol_COUNT):
+            raise ValueError("Unknown style variable: {}".format(variable))
+
+        self._check_ptr()
+        cdef int ix = variable
+        return _cast_ImVec4_tuple(self._ptr.Colors[ix])
+
+    @property
+    def colors(self):
+        """Retrieve and modify style colors through list-like interface.
+
+        .. visual-example::
+            :width: 700
+            :height: 500
+            :auto_layout:
+
+            style = imgui.get_style()
+            imgui.begin("Color window")
+            imgui.columns(4)
+            for color in range(0, imgui.COLOR_COUNT):
+                imgui.text("Color: {}".format(color))
+                imgui.color_button("color#{}".format(color), *style.colors[color])
+                imgui.next_column()
+
+            imgui.end()
+        """
+        self._check_ptr()
+        return self._colors
+
+    ## ImPlotColormap Colormap
+
+    @property
+    def colormap(self):
+        self._check_ptr()
+        return self._ptr.Colormap
+
+    @colormap.setter
+    def colormap(self, cimplot.ImPlotColormap value):
+        self._check_ptr()
+        self._ptr.Colormap = value
+
+    ## bool AntiAliasedLines
+
+    @property
+    def anti_aliased_lines(self):
+        self._check_ptr()
+        return self._ptr.AntiAliasedLines
+
+    @anti_aliased_lines.setter
+    def anti_aliased_lines(self, cimgui.bool value):
+        self._check_ptr()
+        self._ptr.AntiAliasedLines = value
+
+    ## bool UseLocalTime
+
+    @property
+    def use_local_time(self):
+        self._check_ptr()
+        return self._ptr.UseLocalTime
+
+    @use_local_time.setter
+    def use_local_time(self, cimgui.bool value):
+        self._check_ptr()
+        self._ptr.UseLocalTime = value
+
+    ## bool UseISO8601
+
+    @property
+    def use_i_s_o8601(self):
+        self._check_ptr()
+        return self._ptr.UseISO8601
+
+    @use_i_s_o8601.setter
+    def use_i_s_o8601(self, cimgui.bool value):
+        self._check_ptr()
+        self._ptr.UseISO8601 = value
+
+    ## bool Use24HourClock
+
+    @property
+    def use24_hour_clock(self):
+        self._check_ptr()
+        return self._ptr.Use24HourClock
+
+    @use24_hour_clock.setter
+    def use24_hour_clock(self, cimgui.bool value):
+        self._check_ptr()
+        self._ptr.Use24HourClock = value
+
+
+##########################################################################################3
+
+
+def create_context():
+    cdef cimplot.ImPlotContext* _ptr
+    _ptr = cimplot.CreateContext()
+    return _ImPlotContext.from_ptr(_ptr)
+
+
+def destroy_context(_ImPlotContext ctx = None):
+    if ctx and ctx._ptr != NULL:
+        cimplot.DestroyContext(ctx._ptr)
+        ctx._ptr = NULL
+    else:
+        raise RuntimeError("Context invalid (None or destroyed)")
+
+
+def get_current_context():
+    cdef cimplot.ImPlotContext* _ptr
+    _ptr = cimplot.GetCurrentContext()
+    return _ImPlotContext.from_ptr(_ptr)
+
+
+def set_current_context(_ImPlotContext ctx):
+    cimplot.SetCurrentContext(ctx._ptr)
+
+
+def set_imgui_context(core._ImGuiContext ctx):
+    if ctx._ptr == NULL:
+        raise RuntimeError("ImGui Context invalid (None or destroyed)")
+    cimplot.SetImGuiContext(ctx._ptr)
+
+
+def begin_plot(str title_id,
+               str x_label = None,
+               str y_label = None,
+               size = (-1,0),
+               cimplot.ImPlotFlags flags = cimplot.ImPlotFlags_None,
+               cimplot.ImPlotAxisFlags x_flags = cimplot.ImPlotAxisFlags_None,
+               cimplot.ImPlotAxisFlags y_flags = cimplot.ImPlotAxisFlags_None,
+               cimplot.ImPlotAxisFlags y2_flags = cimplot.ImPlotAxisFlags_NoGridLines,
+               cimplot.ImPlotAxisFlags y3_flags = cimplot.ImPlotAxisFlags_NoGridLines,
+               str y2_label = None,
+               str y3_label = None):
+    cdef char* c_x_label = NULL
+    if x_label is not None:
+        py_x_label = _bytes(x_label)
+        c_x_label = py_x_label
+    cdef char* c_y_label = NULL
+    if y_label is not None:
+        py_y_label = _bytes(y_label)
+        c_y_label = py_y_label
+    cdef char* c_y2_label = NULL
+    if y2_label is not None:
+        py_y2_label = _bytes(y2_label)
+        c_y2_label = py_y2_label
+    cdef char* c_y3_label = NULL
+    if y3_label is not None:
+        py_y3_label = _bytes(y3_label)
+        c_y3_label = py_y3_label
+    return cimplot.BeginPlot(
+        _bytes(title_id),
+        c_x_label, c_y_label,
+        _cast_tuple_ImVec2(size),
+        flags, x_flags, y_flags, y2_flags, y3_flags,
+        c_y2_label, c_y3_label)
+
+
+def end_plot():
+    cimplot.EndPlot()
+
+
+cdef class _callback_info(object):
+
+    cdef object callback_fn
+    cdef user_data
+
+    def __init__(self):
+        pass
+
+    def populate(self, callback_fn, user_data):
+        if callable(callback_fn):
+            self.callback_fn = callback_fn
+            self.user_data = user_data
+        else:
+            raise ValueError("callback_fn is not a callable: %s" % str(callback_fn))
+
+
+cdef cimplot.ImPlotPoint _ImPlotGetterCallback(void* data, int idx):
+    cdef _callback_info _cb_info = <_callback_info>(data)
+    x, y = _cb_info.callback_fn(_cb_info.user_data, idx)
+    cdef cimplot.ImPlotPoint point
+    point.x = x
+    point.y = y
+    return point
+
+
+def plot_line1(str label_id, array.array values, int count, double xscale=1, double x0=0, int offset=0, int stride=0):
+    if values.typecode == 'd':
+        cimplot.PlotLine1[double](_bytes(label_id), values.data.as_doubles, count, xscale, x0, offset, sizeof(double))
+    elif values.typecode == 'f':
+        cimplot.PlotLine1[float](_bytes(label_id), values.data.as_floats, count, xscale, x0, offset, sizeof(float))
+    elif values.typecode == 'q':
+        cimplot.PlotLine1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>values.data.as_longlongs, count, xscale, x0, offset, sizeof(cimgui.ImS64))
+    elif values.typecode == 'Q':
+        cimplot.PlotLine1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>values.data.as_ulonglongs, count, xscale, x0, offset, sizeof(cimgui.ImU64))
+    elif values.typecode == 'l':
+        cimplot.PlotLine1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>values.data.as_longs, count, xscale, x0, offset, sizeof(cimgui.ImS32))
+    elif values.typecode == 'L':
+        cimplot.PlotLine1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>values.data.as_ulongs, count, xscale, x0, offset, sizeof(cimgui.ImU32))
+    elif values.typecode == 'h':
+        cimplot.PlotLine1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>values.data.as_shorts, count, xscale, x0, offset, sizeof(cimgui.ImS16))
+    elif values.typecode == 'H':
+        cimplot.PlotLine1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>values.data.as_ushorts, count, xscale, x0, offset, sizeof(cimgui.ImU16))
+    elif values.typecode == 'b':
+        cimplot.PlotLine1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>values.data.as_schars, count, xscale, x0, offset, sizeof(cimgui.ImS8))
+    elif values.typecode == 'B':
+        cimplot.PlotLine1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>values.data.as_uchars, count, xscale, x0, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_line2(str label_id, array.array xs, array.array ys, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd':
+        cimplot.PlotLine2[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f':
+        cimplot.PlotLine2[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q':
+        cimplot.PlotLine2[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q':
+        cimplot.PlotLine2[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l':
+        cimplot.PlotLine2[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L':
+        cimplot.PlotLine2[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h':
+        cimplot.PlotLine2[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H':
+        cimplot.PlotLine2[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b':
+        cimplot.PlotLine2[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B':
+        cimplot.PlotLine2[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_lineg(str label_id, object callback, data, int count, int offset=0):
+    cdef _callback_info _cb_info = _callback_info()
+    cdef cimplot.ImPlotGetterCallback _callback = NULL
+    cdef void *_data = NULL
+    if callback is not None:
+        _callback = _ImPlotGetterCallback
+        _cb_info.populate(callback, data)
+        _data = <void*>_cb_info
+    cimplot.PlotLineG(_bytes(label_id), _callback, _data, count, offset)
+
+
+def plot_scatter1(str label_id, array.array values, int count, double xscale=1, double x0=0, int offset=0, int stride=0):
+    if values.typecode == 'd':
+        cimplot.PlotScatter1[double](_bytes(label_id), values.data.as_doubles, count, xscale, x0, offset, sizeof(double))
+    elif values.typecode == 'f':
+        cimplot.PlotScatter1[float](_bytes(label_id), values.data.as_floats, count, xscale, x0, offset, sizeof(float))
+    elif values.typecode == 'q':
+        cimplot.PlotScatter1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>values.data.as_longlongs, count, xscale, x0, offset, sizeof(cimgui.ImS64))
+    elif values.typecode == 'Q':
+        cimplot.PlotScatter1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>values.data.as_ulonglongs, count, xscale, x0, offset, sizeof(cimgui.ImU64))
+    elif values.typecode == 'l':
+        cimplot.PlotScatter1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>values.data.as_longs, count, xscale, x0, offset, sizeof(cimgui.ImS32))
+    elif values.typecode == 'L':
+        cimplot.PlotScatter1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>values.data.as_ulongs, count, xscale, x0, offset, sizeof(cimgui.ImU32))
+    elif values.typecode == 'h':
+        cimplot.PlotScatter1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>values.data.as_shorts, count, xscale, x0, offset, sizeof(cimgui.ImS16))
+    elif values.typecode == 'H':
+        cimplot.PlotScatter1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>values.data.as_ushorts, count, xscale, x0, offset, sizeof(cimgui.ImU16))
+    elif values.typecode == 'b':
+        cimplot.PlotScatter1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>values.data.as_schars, count, xscale, x0, offset, sizeof(cimgui.ImS8))
+    elif values.typecode == 'B':
+        cimplot.PlotScatter1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>values.data.as_uchars, count, xscale, x0, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_scatter2(str label_id, array.array xs, array.array ys, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd':
+        cimplot.PlotScatter2[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f':
+        cimplot.PlotScatter2[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q':
+        cimplot.PlotScatter2[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q':
+        cimplot.PlotScatter2[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l':
+        cimplot.PlotScatter2[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L':
+        cimplot.PlotScatter2[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h':
+        cimplot.PlotScatter2[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H':
+        cimplot.PlotScatter2[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b':
+        cimplot.PlotScatter2[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B':
+        cimplot.PlotScatter2[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_scatterg(str label_id, object callback, data, int count, int offset=0):
+    cdef _callback_info _cb_info = _callback_info()
+    cdef cimplot.ImPlotGetterCallback _callback = NULL
+    cdef void *_data = NULL
+    if callback is not None:
+        _callback = _ImPlotGetterCallback
+        _cb_info.populate(callback, data)
+        _data = <void*>_cb_info
+    cimplot.PlotScatterG(_bytes(label_id), _callback, _data, count, offset)
+
+
+def plot_stairs1(str label_id, array.array values, int count, double xscale=1, double x0=0, int offset=0, int stride=0):
+    if values.typecode == 'd':
+        cimplot.PlotStairs1[double](_bytes(label_id), values.data.as_doubles, count, xscale, x0, offset, sizeof(double))
+    elif values.typecode == 'f':
+        cimplot.PlotStairs1[float](_bytes(label_id), values.data.as_floats, count, xscale, x0, offset, sizeof(float))
+    elif values.typecode == 'q':
+        cimplot.PlotStairs1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>values.data.as_longlongs, count, xscale, x0, offset, sizeof(cimgui.ImS64))
+    elif values.typecode == 'Q':
+        cimplot.PlotStairs1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>values.data.as_ulonglongs, count, xscale, x0, offset, sizeof(cimgui.ImU64))
+    elif values.typecode == 'l':
+        cimplot.PlotStairs1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>values.data.as_longs, count, xscale, x0, offset, sizeof(cimgui.ImS32))
+    elif values.typecode == 'L':
+        cimplot.PlotStairs1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>values.data.as_ulongs, count, xscale, x0, offset, sizeof(cimgui.ImU32))
+    elif values.typecode == 'h':
+        cimplot.PlotStairs1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>values.data.as_shorts, count, xscale, x0, offset, sizeof(cimgui.ImS16))
+    elif values.typecode == 'H':
+        cimplot.PlotStairs1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>values.data.as_ushorts, count, xscale, x0, offset, sizeof(cimgui.ImU16))
+    elif values.typecode == 'b':
+        cimplot.PlotStairs1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>values.data.as_schars, count, xscale, x0, offset, sizeof(cimgui.ImS8))
+    elif values.typecode == 'B':
+        cimplot.PlotStairs1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>values.data.as_uchars, count, xscale, x0, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_stairs2(str label_id, array.array xs, array.array ys, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd':
+        cimplot.PlotStairs2[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f':
+        cimplot.PlotStairs2[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q':
+        cimplot.PlotStairs2[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q':
+        cimplot.PlotStairs2[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l':
+        cimplot.PlotStairs2[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L':
+        cimplot.PlotStairs2[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h':
+        cimplot.PlotStairs2[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H':
+        cimplot.PlotStairs2[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b':
+        cimplot.PlotStairs2[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B':
+        cimplot.PlotStairs2[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_stairsg(str label_id, object callback, data, int count, int offset=0):
+    cdef _callback_info _cb_info = _callback_info()
+    cdef cimplot.ImPlotGetterCallback _callback = NULL
+    cdef void *_data = NULL
+    if callback is not None:
+        _callback = _ImPlotGetterCallback
+        _cb_info.populate(callback, data)
+        _data = <void*>_cb_info
+    cimplot.PlotStairsG(_bytes(label_id), _callback, _data, count, offset)
+
+
+def plot_shaded1(str label_id, array.array values, int count, double y_ref=0, double xscale=1, double x0=0, int offset=0, int stride=0):
+    if values.typecode == 'd':
+        cimplot.PlotShaded1[double](_bytes(label_id), values.data.as_doubles, count, y_ref, xscale, x0, offset, sizeof(double))
+    elif values.typecode == 'f':
+        cimplot.PlotShaded1[float](_bytes(label_id), values.data.as_floats, count, y_ref, xscale, x0, offset, sizeof(float))
+    elif values.typecode == 'q':
+        cimplot.PlotShaded1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>values.data.as_longlongs, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImS64))
+    elif values.typecode == 'Q':
+        cimplot.PlotShaded1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>values.data.as_ulonglongs, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImU64))
+    elif values.typecode == 'l':
+        cimplot.PlotShaded1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>values.data.as_longs, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImS32))
+    elif values.typecode == 'L':
+        cimplot.PlotShaded1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>values.data.as_ulongs, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImU32))
+    elif values.typecode == 'h':
+        cimplot.PlotShaded1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>values.data.as_shorts, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImS16))
+    elif values.typecode == 'H':
+        cimplot.PlotShaded1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>values.data.as_ushorts, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImU16))
+    elif values.typecode == 'b':
+        cimplot.PlotShaded1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>values.data.as_schars, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImS8))
+    elif values.typecode == 'B':
+        cimplot.PlotShaded1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>values.data.as_uchars, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_shaded2(str label_id, array.array xs, array.array ys, int count, double y_ref=0, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd':
+        cimplot.PlotShaded2[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, count, y_ref, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f':
+        cimplot.PlotShaded2[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, count, y_ref, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q':
+        cimplot.PlotShaded2[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, count, y_ref, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q':
+        cimplot.PlotShaded2[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, count, y_ref, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l':
+        cimplot.PlotShaded2[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, count, y_ref, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L':
+        cimplot.PlotShaded2[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, count, y_ref, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h':
+        cimplot.PlotShaded2[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, count, y_ref, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H':
+        cimplot.PlotShaded2[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, count, y_ref, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b':
+        cimplot.PlotShaded2[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, count, y_ref, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B':
+        cimplot.PlotShaded2[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, count, y_ref, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_shaded3(str label_id, array.array xs, array.array ys1, array.array ys2, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys1.typecode == 'd' and ys2.typecode == 'd':
+        cimplot.PlotShaded3[double](_bytes(label_id), xs.data.as_doubles, ys1.data.as_doubles, ys2.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys1.typecode == 'f' and ys2.typecode == 'f':
+        cimplot.PlotShaded3[float](_bytes(label_id), xs.data.as_floats, ys1.data.as_floats, ys2.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys1.typecode == 'q' and ys2.typecode == 'q':
+        cimplot.PlotShaded3[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys1.data.as_longlongs, <cimgui.ImS64*>ys2.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys1.typecode == 'Q' and ys2.typecode == 'Q':
+        cimplot.PlotShaded3[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys1.data.as_ulonglongs, <cimgui.ImU64*>ys2.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys1.typecode == 'l' and ys2.typecode == 'l':
+        cimplot.PlotShaded3[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys1.data.as_longs, <cimgui.ImS32*>ys2.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys1.typecode == 'L' and ys2.typecode == 'L':
+        cimplot.PlotShaded3[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys1.data.as_ulongs, <cimgui.ImU32*>ys2.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys1.typecode == 'h' and ys2.typecode == 'h':
+        cimplot.PlotShaded3[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys1.data.as_shorts, <cimgui.ImS16*>ys2.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys1.typecode == 'H' and ys2.typecode == 'H':
+        cimplot.PlotShaded3[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys1.data.as_ushorts, <cimgui.ImU16*>ys2.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys1.typecode == 'b' and ys2.typecode == 'b':
+        cimplot.PlotShaded3[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys1.data.as_schars, <cimgui.ImS8*>ys2.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys1.typecode == 'B' and ys2.typecode == 'B':
+        cimplot.PlotShaded3[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys1.data.as_uchars, <cimgui.ImU8*>ys2.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_shadedg(str label_id, object callback1, data1, object callback2, data2, int count, int offset=0):
+    cdef _callback_info _cb_info1 = _callback_info()
+    cdef cimplot.ImPlotGetterCallback _callback = NULL
+    cdef void *_data1 = NULL
+    if callback1 is not None:
+        _callback1 = _ImPlotGetterCallback
+        _cb_info1.populate(callback1, data1)
+        _data1 = <void*>_cb_info1
+    cdef _callback_info _cb_info2 = _callback_info()
+    cdef cimplot.ImPlotPoint (*_callback2)(void* data, int idx)
+    cdef void *_data2 = NULL
+    if callback2 is not None:
+        _callback2 = _ImPlotGetterCallback
+        _cb_info2.populate(callback2, data2)
+        _data2 = <void*>_cb_info2
+    cimplot.PlotShadedG(_bytes(label_id), _callback1, _data1, _callback2, _data2, count, offset)
+
+
+def plot_bars1(str label_id, array.array values, int count, double width=0.67, double shift=0, int offset=0, int stride=0):
+    if values.typecode == 'd':
+        cimplot.PlotBars1[double](_bytes(label_id), values.data.as_doubles, count, width, shift, offset, sizeof(double))
+    elif values.typecode == 'f':
+        cimplot.PlotBars1[float](_bytes(label_id), values.data.as_floats, count, width, shift, offset, sizeof(float))
+    elif values.typecode == 'q':
+        cimplot.PlotBars1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>values.data.as_longlongs, count, width, shift, offset, sizeof(cimgui.ImS64))
+    elif values.typecode == 'Q':
+        cimplot.PlotBars1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>values.data.as_ulonglongs, count, width, shift, offset, sizeof(cimgui.ImU64))
+    elif values.typecode == 'l':
+        cimplot.PlotBars1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>values.data.as_longs, count, width, shift, offset, sizeof(cimgui.ImS32))
+    elif values.typecode == 'L':
+        cimplot.PlotBars1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>values.data.as_ulongs, count, width, shift, offset, sizeof(cimgui.ImU32))
+    elif values.typecode == 'h':
+        cimplot.PlotBars1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>values.data.as_shorts, count, width, shift, offset, sizeof(cimgui.ImS16))
+    elif values.typecode == 'H':
+        cimplot.PlotBars1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>values.data.as_ushorts, count, width, shift, offset, sizeof(cimgui.ImU16))
+    elif values.typecode == 'b':
+        cimplot.PlotBars1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>values.data.as_schars, count, width, shift, offset, sizeof(cimgui.ImS8))
+    elif values.typecode == 'B':
+        cimplot.PlotBars1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>values.data.as_uchars, count, width, shift, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_bars2(str label_id, array.array xs, array.array ys, int count, double width, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd':
+        cimplot.PlotBars2[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, count, width, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f':
+        cimplot.PlotBars2[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, count, width, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q':
+        cimplot.PlotBars2[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, count, width, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q':
+        cimplot.PlotBars2[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, count, width, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l':
+        cimplot.PlotBars2[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, count, width, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L':
+        cimplot.PlotBars2[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, count, width, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h':
+        cimplot.PlotBars2[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, count, width, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H':
+        cimplot.PlotBars2[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, count, width, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b':
+        cimplot.PlotBars2[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, count, width, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B':
+        cimplot.PlotBars2[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, count, width, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_barsg(str label_id, object callback, data, int count, double width, int offset=0):
+    cdef _callback_info _cb_info = _callback_info()
+    cdef cimplot.ImPlotGetterCallback _callback = NULL
+    cdef void *_data = NULL
+    if callback is not None:
+        _callback = _ImPlotGetterCallback
+        _cb_info.populate(callback, data)
+        _data = <void*>_cb_info
+    cimplot.PlotBarsG(_bytes(label_id), _callback, _data, count, width, offset)
+
+
+def plot_barsh1(str label_id, array.array values, int count, double height=0.67, double shift=0, int offset=0, int stride=0):
+    if values.typecode == 'd':
+        cimplot.PlotBarsH1[double](_bytes(label_id), values.data.as_doubles, count, height, shift, offset, sizeof(double))
+    elif values.typecode == 'f':
+        cimplot.PlotBarsH1[float](_bytes(label_id), values.data.as_floats, count, height, shift, offset, sizeof(float))
+    elif values.typecode == 'q':
+        cimplot.PlotBarsH1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>values.data.as_longlongs, count, height, shift, offset, sizeof(cimgui.ImS64))
+    elif values.typecode == 'Q':
+        cimplot.PlotBarsH1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>values.data.as_ulonglongs, count, height, shift, offset, sizeof(cimgui.ImU64))
+    elif values.typecode == 'l':
+        cimplot.PlotBarsH1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>values.data.as_longs, count, height, shift, offset, sizeof(cimgui.ImS32))
+    elif values.typecode == 'L':
+        cimplot.PlotBarsH1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>values.data.as_ulongs, count, height, shift, offset, sizeof(cimgui.ImU32))
+    elif values.typecode == 'h':
+        cimplot.PlotBarsH1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>values.data.as_shorts, count, height, shift, offset, sizeof(cimgui.ImS16))
+    elif values.typecode == 'H':
+        cimplot.PlotBarsH1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>values.data.as_ushorts, count, height, shift, offset, sizeof(cimgui.ImU16))
+    elif values.typecode == 'b':
+        cimplot.PlotBarsH1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>values.data.as_schars, count, height, shift, offset, sizeof(cimgui.ImS8))
+    elif values.typecode == 'B':
+        cimplot.PlotBarsH1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>values.data.as_uchars, count, height, shift, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_barsh2(str label_id, array.array xs, array.array ys, int count, double height, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd':
+        cimplot.PlotBarsH2[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, count, height, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f':
+        cimplot.PlotBarsH2[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, count, height, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q':
+        cimplot.PlotBarsH2[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, count, height, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q':
+        cimplot.PlotBarsH2[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, count, height, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l':
+        cimplot.PlotBarsH2[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, count, height, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L':
+        cimplot.PlotBarsH2[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, count, height, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h':
+        cimplot.PlotBarsH2[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, count, height, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H':
+        cimplot.PlotBarsH2[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, count, height, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b':
+        cimplot.PlotBarsH2[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, count, height, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B':
+        cimplot.PlotBarsH2[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, count, height, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_barshg(str label_id, object callback, data, int count, double height, int offset=0):
+    cdef _callback_info _cb_info = _callback_info()
+    cdef cimplot.ImPlotGetterCallback _callback = NULL
+    cdef void *_data = NULL
+    if callback is not None:
+        _callback = _ImPlotGetterCallback
+        _cb_info.populate(callback, data)
+        _data = <void*>_cb_info
+    cimplot.PlotBarsHG(_bytes(label_id), _callback, _data, count, height, offset)
+
+
+def plot_error_bars1(str label_id, array.array xs, array.array ys, array.array err, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd' and err.typecode == 'd':
+        cimplot.PlotErrorBars1[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, err.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f' and err.typecode == 'f':
+        cimplot.PlotErrorBars1[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, err.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q' and err.typecode == 'q':
+        cimplot.PlotErrorBars1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, <cimgui.ImS64*>err.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q' and err.typecode == 'Q':
+        cimplot.PlotErrorBars1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, <cimgui.ImU64*>err.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l' and err.typecode == 'l':
+        cimplot.PlotErrorBars1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, <cimgui.ImS32*>err.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L' and err.typecode == 'L':
+        cimplot.PlotErrorBars1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, <cimgui.ImU32*>err.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h' and err.typecode == 'h':
+        cimplot.PlotErrorBars1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, <cimgui.ImS16*>err.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H' and err.typecode == 'H':
+        cimplot.PlotErrorBars1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, <cimgui.ImU16*>err.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b' and err.typecode == 'b':
+        cimplot.PlotErrorBars1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, <cimgui.ImS8*>err.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B' and err.typecode == 'B':
+        cimplot.PlotErrorBars1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, <cimgui.ImU8*>err.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_error_bars2(str label_id, array.array xs, array.array ys, array.array neg, array.array pos, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd' and neg.typecode == 'd' and pos.typecode == 'd':
+        cimplot.PlotErrorBars2[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, neg.data.as_doubles, pos.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f' and neg.typecode == 'f' and pos.typecode == 'f':
+        cimplot.PlotErrorBars2[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, neg.data.as_floats, pos.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q' and neg.typecode == 'q' and pos.typecode == 'q':
+        cimplot.PlotErrorBars2[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, <cimgui.ImS64*>neg.data.as_longlongs, <cimgui.ImS64*>pos.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q' and neg.typecode == 'Q' and pos.typecode == 'Q':
+        cimplot.PlotErrorBars2[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, <cimgui.ImU64*>neg.data.as_ulonglongs, <cimgui.ImU64*>pos.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l' and neg.typecode == 'l' and pos.typecode == 'l':
+        cimplot.PlotErrorBars2[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, <cimgui.ImS32*>neg.data.as_longs, <cimgui.ImS32*>pos.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L' and neg.typecode == 'L' and pos.typecode == 'L':
+        cimplot.PlotErrorBars2[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, <cimgui.ImU32*>neg.data.as_ulongs, <cimgui.ImU32*>pos.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h' and neg.typecode == 'h' and pos.typecode == 'h':
+        cimplot.PlotErrorBars2[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, <cimgui.ImS16*>neg.data.as_shorts, <cimgui.ImS16*>pos.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H' and neg.typecode == 'H' and pos.typecode == 'H':
+        cimplot.PlotErrorBars2[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, <cimgui.ImU16*>neg.data.as_ushorts, <cimgui.ImU16*>pos.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b' and neg.typecode == 'b' and pos.typecode == 'b':
+        cimplot.PlotErrorBars2[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, <cimgui.ImS8*>neg.data.as_schars, <cimgui.ImS8*>pos.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B' and neg.typecode == 'B' and pos.typecode == 'B':
+        cimplot.PlotErrorBars2[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, <cimgui.ImU8*>neg.data.as_uchars, <cimgui.ImU8*>pos.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_error_barsh1(str label_id, array.array xs, array.array ys, array.array err, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd' and err.typecode == 'd':
+        cimplot.PlotErrorBarsH1[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, err.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f' and err.typecode == 'f':
+        cimplot.PlotErrorBarsH1[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, err.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q' and err.typecode == 'q':
+        cimplot.PlotErrorBarsH1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, <cimgui.ImS64*>err.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q' and err.typecode == 'Q':
+        cimplot.PlotErrorBarsH1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, <cimgui.ImU64*>err.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l' and err.typecode == 'l':
+        cimplot.PlotErrorBarsH1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, <cimgui.ImS32*>err.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L' and err.typecode == 'L':
+        cimplot.PlotErrorBarsH1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, <cimgui.ImU32*>err.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h' and err.typecode == 'h':
+        cimplot.PlotErrorBarsH1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, <cimgui.ImS16*>err.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H' and err.typecode == 'H':
+        cimplot.PlotErrorBarsH1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, <cimgui.ImU16*>err.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b' and err.typecode == 'b':
+        cimplot.PlotErrorBarsH1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, <cimgui.ImS8*>err.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B' and err.typecode == 'B':
+        cimplot.PlotErrorBarsH1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, <cimgui.ImU8*>err.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_error_barsh2(str label_id, array.array xs, array.array ys, array.array neg, array.array pos, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd' and neg.typecode == 'd' and pos.typecode == 'd':
+        cimplot.PlotErrorBarsH2[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, neg.data.as_doubles, pos.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f' and neg.typecode == 'f' and pos.typecode == 'f':
+        cimplot.PlotErrorBarsH2[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, neg.data.as_floats, pos.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q' and neg.typecode == 'q' and pos.typecode == 'q':
+        cimplot.PlotErrorBarsH2[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, <cimgui.ImS64*>neg.data.as_longlongs, <cimgui.ImS64*>pos.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q' and neg.typecode == 'Q' and pos.typecode == 'Q':
+        cimplot.PlotErrorBarsH2[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, <cimgui.ImU64*>neg.data.as_ulonglongs, <cimgui.ImU64*>pos.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l' and neg.typecode == 'l' and pos.typecode == 'l':
+        cimplot.PlotErrorBarsH2[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, <cimgui.ImS32*>neg.data.as_longs, <cimgui.ImS32*>pos.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L' and neg.typecode == 'L' and pos.typecode == 'L':
+        cimplot.PlotErrorBarsH2[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, <cimgui.ImU32*>neg.data.as_ulongs, <cimgui.ImU32*>pos.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h' and neg.typecode == 'h' and pos.typecode == 'h':
+        cimplot.PlotErrorBarsH2[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, <cimgui.ImS16*>neg.data.as_shorts, <cimgui.ImS16*>pos.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H' and neg.typecode == 'H' and pos.typecode == 'H':
+        cimplot.PlotErrorBarsH2[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, <cimgui.ImU16*>neg.data.as_ushorts, <cimgui.ImU16*>pos.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b' and neg.typecode == 'b' and pos.typecode == 'b':
+        cimplot.PlotErrorBarsH2[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, <cimgui.ImS8*>neg.data.as_schars, <cimgui.ImS8*>pos.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B' and neg.typecode == 'B' and pos.typecode == 'B':
+        cimplot.PlotErrorBarsH2[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, <cimgui.ImU8*>neg.data.as_uchars, <cimgui.ImU8*>pos.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_stems1(str label_id, array.array values, int count, double y_ref=0, double xscale=1, double x0=0, int offset=0, int stride=0):
+    if values.typecode == 'd':
+        cimplot.PlotStems1[double](_bytes(label_id), values.data.as_doubles, count, y_ref, xscale, x0, offset, sizeof(double))
+    elif values.typecode == 'f':
+        cimplot.PlotStems1[float](_bytes(label_id), values.data.as_floats, count, y_ref, xscale, x0, offset, sizeof(float))
+    elif values.typecode == 'q':
+        cimplot.PlotStems1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>values.data.as_longlongs, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImS64))
+    elif values.typecode == 'Q':
+        cimplot.PlotStems1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>values.data.as_ulonglongs, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImU64))
+    elif values.typecode == 'l':
+        cimplot.PlotStems1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>values.data.as_longs, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImS32))
+    elif values.typecode == 'L':
+        cimplot.PlotStems1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>values.data.as_ulongs, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImU32))
+    elif values.typecode == 'h':
+        cimplot.PlotStems1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>values.data.as_shorts, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImS16))
+    elif values.typecode == 'H':
+        cimplot.PlotStems1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>values.data.as_ushorts, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImU16))
+    elif values.typecode == 'b':
+        cimplot.PlotStems1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>values.data.as_schars, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImS8))
+    elif values.typecode == 'B':
+        cimplot.PlotStems1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>values.data.as_uchars, count, y_ref, xscale, x0, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_stems2(str label_id, array.array xs, array.array ys, int count, double y_ref=0, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd':
+        cimplot.PlotStems2[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, count, y_ref, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f':
+        cimplot.PlotStems2[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, count, y_ref, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q':
+        cimplot.PlotStems2[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, count, y_ref, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q':
+        cimplot.PlotStems2[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, count, y_ref, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l':
+        cimplot.PlotStems2[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, count, y_ref, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L':
+        cimplot.PlotStems2[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, count, y_ref, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h':
+        cimplot.PlotStems2[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, count, y_ref, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H':
+        cimplot.PlotStems2[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, count, y_ref, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b':
+        cimplot.PlotStems2[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, count, y_ref, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B':
+        cimplot.PlotStems2[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, count, y_ref, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_vlines1(str label_id, array.array xs, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd':
+        cimplot.PlotVLines1[double](_bytes(label_id), xs.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f':
+        cimplot.PlotVLines1[float](_bytes(label_id), xs.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q':
+        cimplot.PlotVLines1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q':
+        cimplot.PlotVLines1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l':
+        cimplot.PlotVLines1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L':
+        cimplot.PlotVLines1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h':
+        cimplot.PlotVLines1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H':
+        cimplot.PlotVLines1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b':
+        cimplot.PlotVLines1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B':
+        cimplot.PlotVLines1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_hlines1(str label_id, array.array ys, int count, int offset=0, int stride=0):
+    if ys.typecode == 'd':
+        cimplot.PlotHLines1[double](_bytes(label_id), ys.data.as_doubles, count, offset, sizeof(double))
+    elif ys.typecode == 'f':
+        cimplot.PlotHLines1[float](_bytes(label_id), ys.data.as_floats, count, offset, sizeof(float))
+    elif ys.typecode == 'q':
+        cimplot.PlotHLines1[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>ys.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif ys.typecode == 'Q':
+        cimplot.PlotHLines1[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>ys.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif ys.typecode == 'l':
+        cimplot.PlotHLines1[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>ys.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif ys.typecode == 'L':
+        cimplot.PlotHLines1[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>ys.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif ys.typecode == 'h':
+        cimplot.PlotHLines1[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>ys.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif ys.typecode == 'H':
+        cimplot.PlotHLines1[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>ys.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif ys.typecode == 'b':
+        cimplot.PlotHLines1[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>ys.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif ys.typecode == 'B':
+        cimplot.PlotHLines1[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>ys.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+
+def plot_pie_chart(label_ids, array.array values, int count, double x, double y, double radius, bool normalize=False, str label_fmt="%.1f", double angle0=90):
+    # XXX: add checks for n_ticks == len(labels), and more..
+    # create python reference to labels
+    py_label_ids = [_bytes(label_id) for label_id in label_ids]
+    # create C strings from above python references
+    cdef char **c_label_ids = NULL
+    cdef int i
+    c_label_ids = <char **>malloc(len(label_ids) * sizeof(char *))
+    for i, s in enumerate(py_label_ids):
+        c_label_ids[i] = s
+
+    if values.typecode == 'd':
+        cimplot.PlotPieChart[double](c_label_ids, values.data.as_doubles, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    elif values.typecode == 'f':
+        cimplot.PlotPieChart[float](c_label_ids, values.data.as_floats, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    elif values.typecode == 'q':
+        cimplot.PlotPieChart[cimgui.ImS64](c_label_ids, <cimgui.ImS64*>values.data.as_longlongs, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    elif values.typecode == 'Q':
+        cimplot.PlotPieChart[cimgui.ImU64](c_label_ids, <cimgui.ImU64*>values.data.as_ulonglongs, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    elif values.typecode == 'l':
+        cimplot.PlotPieChart[cimgui.ImS32](c_label_ids, <cimgui.ImS32*>values.data.as_longs, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    elif values.typecode == 'L':
+        cimplot.PlotPieChart[cimgui.ImU32](c_label_ids, <cimgui.ImU32*>values.data.as_ulongs, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    elif values.typecode == 'h':
+        cimplot.PlotPieChart[cimgui.ImS16](c_label_ids, <cimgui.ImS16*>values.data.as_shorts, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    elif values.typecode == 'H':
+        cimplot.PlotPieChart[cimgui.ImU16](c_label_ids, <cimgui.ImU16*>values.data.as_ushorts, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    elif values.typecode == 'b':
+        cimplot.PlotPieChart[cimgui.ImS8](c_label_ids, <cimgui.ImS8*>values.data.as_schars, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    elif values.typecode == 'B':
+        cimplot.PlotPieChart[cimgui.ImU8](c_label_ids, <cimgui.ImU8*>values.data.as_uchars, count, x, y, radius, normalize, _bytes(label_fmt), angle0)
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+    for i, s in enumerate(py_label_ids):
+        free(c_label_ids[i])
+    free(c_label_ids)
+
+
+def plot_heatmap(str label_id, array.array values, int rows, int cols, double scale_min=0.0, double scale_max=0.0, str label_fmt="%.1f", bounds_min=(0,0), bounds_max=(1,1)):
+    cdef cimplot.ImPlotPoint _bounds_min
+    _bounds_min.x = bounds_min[0]
+    _bounds_min.y = bounds_min[1]
+    cdef cimplot.ImPlotPoint _bounds_max
+    _bounds_max.x = bounds_max[0]
+    _bounds_max.y = bounds_max[1]
+
+    if values.typecode == 'd':
+        cimplot.PlotHeatmap[double](_bytes(label_id), values.data.as_doubles, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    elif values.typecode == 'f':
+        cimplot.PlotHeatmap[float](_bytes(label_id), values.data.as_floats, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    elif values.typecode == 'q':
+        cimplot.PlotHeatmap[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>values.data.as_longlongs, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    elif values.typecode == 'Q':
+        cimplot.PlotHeatmap[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>values.data.as_ulonglongs, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    elif values.typecode == 'l':
+        cimplot.PlotHeatmap[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>values.data.as_longs, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    elif values.typecode == 'L':
+        cimplot.PlotHeatmap[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>values.data.as_ulongs, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    elif values.typecode == 'h':
+        cimplot.PlotHeatmap[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>values.data.as_shorts, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    elif values.typecode == 'H':
+        cimplot.PlotHeatmap[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>values.data.as_ushorts, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    elif values.typecode == 'b':
+        cimplot.PlotHeatmap[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>values.data.as_schars, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    elif values.typecode == 'B':
+        cimplot.PlotHeatmap[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>values.data.as_uchars, rows, cols, scale_min, scale_max, _bytes(label_fmt), _bounds_min, _bounds_max)
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_histogram(str label_id, array.array values, int count, int bins=cimplot.ImPlotBin_Sturges, bool cumulative=False, bool density=False, tuple range=(0.0, 0.0), bool outliers=True, double bar_scale=1.0):
+    cdef cimplot.ImPlotRange _range
+    _range.x = range[0]
+    _range.y = range[1]
+
+    if values.typecode == 'd':
+        cimplot.PlotHistogram[double](_bytes(label_id), values.data.as_doubles, count, bins, cumulative, density, _range, outliers, bar_scale)
+    elif values.typecode == 'f':
+        cimplot.PlotHistogram[float](_bytes(label_id), values.data.as_floats, count, bins, cumulative, density, _range, outliers, bar_scale)
+    elif values.typecode == 'q':
+        cimplot.PlotHistogram[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>values.data.as_longlongs, count, bins, cumulative, density, _range, outliers, bar_scale)
+    elif values.typecode == 'Q':
+        cimplot.PlotHistogram[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>values.data.as_ulonglongs, count, bins, cumulative, density, _range, outliers, bar_scale)
+    elif values.typecode == 'l':
+        cimplot.PlotHistogram[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>values.data.as_longs, count, bins, cumulative, density, _range, outliers, bar_scale)
+    elif values.typecode == 'L':
+        cimplot.PlotHistogram[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>values.data.as_ulongs, count, bins, cumulative, density, _range, outliers, bar_scale)
+    elif values.typecode == 'h':
+        cimplot.PlotHistogram[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>values.data.as_shorts, count, bins, cumulative, density, _range, outliers, bar_scale)
+    elif values.typecode == 'H':
+        cimplot.PlotHistogram[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>values.data.as_ushorts, count, bins, cumulative, density, _range, outliers, bar_scale)
+    elif values.typecode == 'b':
+        cimplot.PlotHistogram[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>values.data.as_schars, count, bins, cumulative, density, _range, outliers, bar_scale)
+    elif values.typecode == 'B':
+        cimplot.PlotHistogram[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>values.data.as_uchars, count, bins, cumulative, density, _range, outliers, bar_scale)
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_histogram_2d(str label_id, array.array xs, array.array ys, int count, int x_bins=cimplot.ImPlotBin_Sturges, int y_bins=cimplot.ImPlotBin_Sturges, bool density=False, tuple range=(0.0, 0.0, 0.0, 0.0), bool outliers=True):
+    cdef cimplot.ImPlotRange _X
+    _X.x = range[0]
+    _X.y = range[1]
+    cdef cimplot.ImPlotRange _Y
+    _Y.x = range[2]
+    _Y.y = range[3]
+    cdef cimplot.ImPlotLimits _range
+    _range.X = _X
+    _range.Y = _Y
+
+    if xs.typecode == 'd' and ys.typecode == 'd':
+        cimplot.PlotHistogram2D[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, count, x_bins, y_bins, density, _range, outliers)
+    elif xs.typecode == 'f' and ys.typecode == 'f':
+        cimplot.PlotHistogram2D[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, count, x_bins, y_bins, density, _range, outliers)
+    elif xs.typecode == 'q' and ys.typecode == 'q':
+        cimplot.PlotHistogram2D[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, count, x_bins, y_bins, density, _range, outliers)
+    elif xs.typecode == 'Q' and ys.typecode == 'Q':
+        cimplot.PlotHistogram2D[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, count, x_bins, y_bins, density, _range, outliers)
+    elif xs.typecode == 'l' and ys.typecode == 'l':
+        cimplot.PlotHistogram2D[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, count, x_bins, y_bins, density, _range, outliers)
+    elif xs.typecode == 'L' and ys.typecode == 'L':
+        cimplot.PlotHistogram2D[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, count, x_bins, y_bins, density, _range, outliers)
+    elif xs.typecode == 'h' and ys.typecode == 'h':
+        cimplot.PlotHistogram2D[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, count, x_bins, y_bins, density, _range, outliers)
+    elif xs.typecode == 'H' and ys.typecode == 'H':
+        cimplot.PlotHistogram2D[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, count, x_bins, y_bins, density, _range, outliers)
+    elif xs.typecode == 'b' and ys.typecode == 'b':
+        cimplot.PlotHistogram2D[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, count, x_bins, y_bins, density, _range, outliers)
+    elif xs.typecode == 'B' and ys.typecode == 'B':
+        cimplot.PlotHistogram2D[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, count, x_bins, y_bins, density, _range, outliers)
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_digital(str label_id, array.array xs, array.array ys, int count, int offset=0, int stride=0):
+    if xs.typecode == 'd' and ys.typecode == 'd':
+        cimplot.PlotDigital[double](_bytes(label_id), xs.data.as_doubles, ys.data.as_doubles, count, offset, sizeof(double))
+    elif xs.typecode == 'f' and ys.typecode == 'f':
+        cimplot.PlotDigital[float](_bytes(label_id), xs.data.as_floats, ys.data.as_floats, count, offset, sizeof(float))
+    elif xs.typecode == 'q' and ys.typecode == 'q':
+        cimplot.PlotDigital[cimgui.ImS64](_bytes(label_id), <cimgui.ImS64*>xs.data.as_longlongs, <cimgui.ImS64*>ys.data.as_longlongs, count, offset, sizeof(cimgui.ImS64))
+    elif xs.typecode == 'Q' and ys.typecode == 'Q':
+        cimplot.PlotDigital[cimgui.ImU64](_bytes(label_id), <cimgui.ImU64*>xs.data.as_ulonglongs, <cimgui.ImU64*>ys.data.as_ulonglongs, count, offset, sizeof(cimgui.ImU64))
+    elif xs.typecode == 'l' and ys.typecode == 'l':
+        cimplot.PlotDigital[cimgui.ImS32](_bytes(label_id), <cimgui.ImS32*>xs.data.as_longs, <cimgui.ImS32*>ys.data.as_longs, count, offset, sizeof(cimgui.ImS32))
+    elif xs.typecode == 'L' and ys.typecode == 'L':
+        cimplot.PlotDigital[cimgui.ImU32](_bytes(label_id), <cimgui.ImU32*>xs.data.as_ulongs, <cimgui.ImU32*>ys.data.as_ulongs, count, offset, sizeof(cimgui.ImU32))
+    elif xs.typecode == 'h' and ys.typecode == 'h':
+        cimplot.PlotDigital[cimgui.ImS16](_bytes(label_id), <cimgui.ImS16*>xs.data.as_shorts, <cimgui.ImS16*>ys.data.as_shorts, count, offset, sizeof(cimgui.ImS16))
+    elif xs.typecode == 'H' and ys.typecode == 'H':
+        cimplot.PlotDigital[cimgui.ImU16](_bytes(label_id), <cimgui.ImU16*>xs.data.as_ushorts, <cimgui.ImU16*>ys.data.as_ushorts, count, offset, sizeof(cimgui.ImU16))
+    elif xs.typecode == 'b' and ys.typecode == 'b':
+        cimplot.PlotDigital[cimgui.ImS8](_bytes(label_id), <cimgui.ImS8*>xs.data.as_schars, <cimgui.ImS8*>ys.data.as_schars, count, offset, sizeof(cimgui.ImS8))
+    elif xs.typecode == 'B' and ys.typecode == 'B':
+        cimplot.PlotDigital[cimgui.ImU8](_bytes(label_id), <cimgui.ImU8*>xs.data.as_uchars, <cimgui.ImU8*>ys.data.as_uchars, count, offset, sizeof(cimgui.ImU8))
+    else:
+        raise ValueError("Style value must be float, double, ImS8, ImU8, ImS16, ImU16, ImS32, ImU32, ImS64, ImU64")
+
+
+def plot_digitalg(str label_id, object callback, data, int count, int offset=0):
+    cdef _callback_info _cb_info = _callback_info()
+    cdef cimplot.ImPlotGetterCallback _callback = NULL
+    cdef void *_data = NULL
+    if callback is not None:
+        _callback = _ImPlotGetterCallback
+        _cb_info.populate(callback, data)
+        _data = <void*>_cb_info
+    cimplot.PlotDigitalG(_bytes(label_id), _callback, _data, count, offset)
+
+
+def plot_text(str text, double x, double y, bool vertical=False, pix_offset=(0,0)):
+    cimplot.PlotText(_bytes(text), x, y, vertical, _cast_tuple_ImVec2(pix_offset))
+
+
+def plot_image(str label_id, user_texture_id, tuple bounds_min, tuple bounds_max, tuple uv0=(0,0), tuple uv1=(1,1), tuple tint_col=(1,1,1,1)):
+    cdef cimplot.ImPlotPoint _bounds_min
+    _bounds_min.x = bounds_min[0]
+    _bounds_min.y = bounds_min[1]
+    cdef cimplot.ImPlotPoint _bounds_max
+    _bounds_max.x = bounds_max[0]
+    _bounds_max.y = bounds_max[1]
+    cimplot.PlotImage(_bytes(label_id), <void*>user_texture_id, _bounds_min, _bounds_max, _cast_tuple_ImVec2(uv0), _cast_tuple_ImVec2(uv1), _cast_tuple_ImVec4(tint_col))
+
+
+def plot_dummy(str label_id):
+    cimplot.PlotDummy(_bytes(label_id))
+
+
+
+
+
+
+def set_next_plot_limits(double xmin, double xmax, double ymin, double ymax, cimgui.ImGuiCond cond = enums.ImGuiCond_Once):
+    cimplot.SetNextPlotLimits(xmin, xmax, ymin, ymax, cond)
+
+
+def set_next_plot_limits_x(double xmin, double xmax, cimgui.ImGuiCond cond = enums.ImGuiCond_Once):
+    cimplot.SetNextPlotLimitsX(xmin, xmax, cond)
+
+
+def set_next_plot_limits_y(double ymin, double ymax, cimgui.ImGuiCond cond = enums.ImGuiCond_Once, cimplot.ImPlotYAxis y_axis = 0):
+    cimplot.SetNextPlotLimitsY(ymin, ymax, cond, y_axis)
+
+
+# XXX: The pointer data must remain valid until the matching call EndPlot.
+#      Q: How to achieve that?!
+#def link_next_plot_limits(double* xmin, double* xmax, double* ymin, double* ymax, double* ymin2 = NULL, double* ymax2 = NULL, double* ymin3 = NULL, double* ymax3 = NULL):
+#    cimplot.LinkNextPlotLimits(double* xmin, double* xmax, double* ymin, double* ymax, double* ymin2 = NULL, double* ymax2 = NULL, double* ymin3 = NULL, double* ymax3 = NULL)
+
+
+def fit_next_plot_axes(bool x = True, bool y = True, bool y2 = True, bool y3 = True):
+    cimplot.FitNextPlotAxes(x, y, y2, y3)
+
+
+def set_next_plot_ticks_x_range(double x_min, double x_max, int n_ticks, labels = None, bool show_default = False):
+    # XXX: NOT tested
+    # XXX: add checks for n_ticks == len(labels), and more..
+    cdef char **c_labels
+    cdef int i
+    if not labels:
+        c_labels = NULL
+    else:
+        c_labels = <char **>malloc(len(labels) * sizeof(char *))
+        for i, s in enumerate(labels):
+            c_labels[i] = s
+    cimplot.SetNextPlotTicksX(x_min, x_max, n_ticks, c_labels, show_default)
+    free(c_labels)
+
+
+def set_next_plot_ticks_x(array.array values, int n_ticks, labels = None, bool show_default = False):
+    # XXX: NOT tested
+    # XXX: add checks for n_ticks == len(labels), and more..
+    cdef char **c_labels
+    cdef int i
+    if not labels:
+        c_labels = NULL
+    else:
+        c_labels = <char **>malloc(len(labels) * sizeof(char *))
+        for i, s in enumerate(labels):
+            c_labels[i] = s
+    cimplot.SetNextPlotTicksX(values.data.as_doubles, n_ticks, c_labels, show_default)
+    free(c_labels)
+
+
+def set_next_plot_ticks_y_range(double y_min, double y_max, int n_ticks, labels = None, bool show_default = False, cimplot.ImPlotYAxis y_axis = 0):
+    # XXX: NOT tested
+    # XXX: add checks for n_ticks == len(labels), and more..
+    cdef char **c_labels
+    cdef int i
+    if not labels:
+        c_labels = NULL
+    else:
+        c_labels = <char **>malloc(len(labels) * sizeof(char *))
+        for i, s in enumerate(labels):
+            c_labels[i] = s
+    cimplot.SetNextPlotTicksY(y_min, y_max, n_ticks, c_labels, show_default, y_axis)
+    free(c_labels)
+
+
+def set_next_plot_ticks_y(array.array values, int n_ticks, labels = None, bool show_default = False, cimplot.ImPlotYAxis y_axis = 0):
+    # XXX: NOT tested
+    # XXX: add checks for n_ticks == len(labels), and more..
+    cdef char **c_labels
+    cdef int i
+    if not labels:
+        c_labels = NULL
+    else:
+        c_labels = <char **>malloc(len(labels) * sizeof(char *))
+        for i, s in enumerate(labels):
+            c_labels[i] = s
+    cimplot.SetNextPlotTicksY(values.data.as_doubles, n_ticks, c_labels, show_default, y_axis)
+    free(c_labels)
+
+
+def set_plot_y_axis(cimplot.ImPlotYAxis y_axis):
+    cimplot.SetPlotYAxis(y_axis)
+
+
+def hide_next_item(bool hidden = True, cimgui.ImGuiCond cond = enums.ImGuiCond_Once):
+    cimplot.HideNextItem(hidden, cond)
+
+
+def pixels_to_plot(float x, float y, cimplot.ImPlotYAxis y_axis = -1):
+    cdef cimplot.ImPlotPoint point
+    point = cimplot.PixelsToPlot(x, y, y_axis)
+    return point.x, point.y
+
+
+def plot_to_pixels(double x, double y, cimplot.ImPlotYAxis y_axis = -1):
+    return _cast_ImVec2_tuple(cimplot.PlotToPixels(x, y, y_axis))
+
+
+def get_plot_pos():
+    return _cast_ImVec2_tuple(cimplot.GetPlotPos())
+
+
+def get_plot_size():
+    return _cast_ImVec2_tuple(cimplot.GetPlotSize())
+
+
+def is_plot_hovered():
+    return cimplot.IsPlotHovered()
+
+def is_plot_x_axis_hovered():
+    return cimplot.IsPlotXAxisHovered()
+
+
+def is_plot_y_axis_hovered(cimplot.ImPlotYAxis y_axis = 0):
+    return cimplot.IsPlotYAxisHovered(y_axis)
+
+
+def get_plot_mouse_pos(cimplot.ImPlotYAxis y_axis = -1):
+    cdef cimplot.ImPlotPoint point
+    point = cimplot.GetPlotMousePos(y_axis)
+    return point.x, point.y
+
+
+def get_plot_limits(cimplot.ImPlotYAxis y_axis = -1):
+    cdef cimplot.ImPlotLimits limits
+    limits = cimplot.GetPlotLimits(y_axis)
+    return limits.X, limits.Y
+
+
+def is_plot_queried():
+    return cimplot.IsPlotQueried()
+
+
+def get_plot_query(cimplot.ImPlotYAxis y_axis = -1):
+    cdef cimplot.ImPlotLimits limits
+    limits = cimplot.GetPlotQuery(y_axis)
+    return limits.X, limits.Y
+
+
+def annotate(double x, double y, double pix_offset_x, double pix_offset_y, str text):
+    cimplot.Annotate(x, y, _cast_args_ImVec2(pix_offset_x, pix_offset_y), "%s", _bytes(text))
+
+
+def annotate_color(double x, double y, double pix_offset_x, double pix_offset_y,
+    float r, float g, float b, float a, str text):
+    cimplot.Annotate(x, y, _cast_args_ImVec2(pix_offset_x, pix_offset_y), _cast_args_ImVec4(r, g, b, a), "%s", _bytes(text))
+
+
+def annotate_clamped(double x, double y, double pix_offset_x, double pix_offset_y, str text):
+    cimplot.AnnotateClamped(x, y, _cast_args_ImVec2(pix_offset_x, pix_offset_y), "%s", _bytes(text))
+
+
+def annotate_clamped_color(double x, double y, double pix_offset_x, double pix_offset_y,
+    float r, float g, float b, float a, str text):
+    cimplot.AnnotateClamped(x, y, _cast_args_ImVec2(pix_offset_x, pix_offset_y), _cast_args_ImVec4(r, g, b, a), "%s", _bytes(text))
+
+def drag_line_x(str id, double x_value, bool show_label = True,
+    float r = 0., float g = 0., float b = 0., float a = -1., float thickness = 1.):
+    cdef double inout_x = x_value
+    return cimplot.DragLineX(
+        _bytes(id), &inout_x, show_label, _cast_args_ImVec4(r, g, b, a), thickness
+    ), inout_x
+
+
+def drag_line_y(str id, double y_value, bool show_label = True,
+    float r = 0., float g = 0., float b = 0., float a = -1., float thickness = 1.):
+    cdef double inout_y = y_value
+    return cimplot.DragLineY(
+        _bytes(id), &inout_y, show_label, _cast_args_ImVec4(r, g, b, a), thickness
+    ), inout_y
+
+
+def drag_point(str id, double x, double y, bool show_label = True,
+    float r = 0., float g = 0., float b = 0., float a = -1., float radius = 4.):
+    cdef double inout_x = x
+    cdef double inout_y = y
+    return cimplot.DragPoint(
+        _bytes(id), &inout_x, &inout_y, show_label, _cast_args_ImVec4(r, g, b, a), radius
+    ), inout_x, inout_y
+
+
+def set_legend_location(cimplot.ImPlotLocation location, cimplot.ImPlotOrientation orientation = cimplot.ImPlotOrientation_Vertical, bool outside = False):
+    cimplot.SetLegendLocation(location, orientation, outside)
+
+
+def set_mouse_pos_location(cimplot.ImPlotLocation location):
+    cimplot.SetMousePosLocation(location)
+
+
+def is_legend_entry_hovered(str label_id):
+    return cimplot.IsLegendEntryHovered(label_id)
+
+
+def begin_legend_popup(str label_id, cimgui.ImGuiMouseButton mouse_button = enums.ImGuiMouseButton_Right):
+    return cimplot.BeginLegendPopup(label_id, mouse_button)
+
+
+def end_legend_popup():
+    cimplot.EndLegendPopup()
+
+
+def begin_drag_drop_target():
+    return cimplot.BeginDragDropTarget()
+
+
+def begin_drag_drop_target_x():
+    return cimplot.BeginDragDropTargetX()
+
+
+def begin_drag_drop_target_y(cimplot.ImPlotYAxis axis = cimplot.ImPlotYAxis_1):
+    return cimplot.BeginDragDropTargetY(axis)
+
+
+def begin_drag_drop_target_legend():
+    return cimplot.BeginDragDropTargetLegend()
+
+
+def end_drag_drop_target():
+    cimplot.EndDragDropTarget()
+
+
+def begin_drag_drop_source(cimgui.ImGuiKeyModFlags key_mods = enums.ImGuiKeyModFlags_Ctrl, cimgui.ImGuiDragDropFlags flags = 0):
+    return cimplot.BeginDragDropSource(key_mods, flags)
+
+
+def begin_drag_drop_source_x(cimgui.ImGuiKeyModFlags key_mods = enums.ImGuiKeyModFlags_Ctrl, cimgui.ImGuiDragDropFlags flags = 0):
+    return cimplot.BeginDragDropSourceX(key_mods, flags)
+
+
+def begin_drag_drop_source_y(cimplot.ImPlotYAxis axis = cimplot.ImPlotYAxis_1, cimgui.ImGuiKeyModFlags key_mods = enums.ImGuiKeyModFlags_Ctrl, cimgui.ImGuiDragDropFlags flags = 0):
+    return cimplot.BeginDragDropSourceY(axis, key_mods, flags)
+
+
+def begin_drag_drop_source_item(str label_id, cimgui.ImGuiDragDropFlags flags=0):
+    return cimplot.BeginDragDropSourceItem(label_id, flags)
+
+
+def end_drag_drop_source():
+    cimplot.EndDragDropSource()
+
+
+def get_style():
+    return PlotStyle.from_ref(cimplot.GetStyle())
+
+
+def style_colors_auto(PlotStyle dst = None):
+    if dst:
+        cimplot.StyleColorsAuto(dst._ptr)
+    else:
+        cimplot.StyleColorsAuto(NULL)
+
+
+def style_colors_dark(PlotStyle dst = None):
+    if dst:
+        cimplot.StyleColorsDark(dst._ptr)
+    else:
+        cimplot.StyleColorsDark(NULL)
+
+
+def style_colors_classic(PlotStyle dst = None):
+    if dst:
+        cimplot.StyleColorsClassic(dst._ptr)
+    else:
+        cimplot.StyleColorsClassic(NULL)
+
+
+def style_colors_light(PlotStyle dst = None):
+    if dst:
+        cimplot.StyleColorsLight(dst._ptr)
+    else:
+        cimplot.StyleColorsLight(NULL)
+
+
+def push_style_var(cimplot.ImPlotStyleVar variable, value):
+    if not (0 <= variable < cimplot.ImPlotStyleVar_COUNT):
+        warnings.warn("Unknown style variable: {}".format(variable))
+        return False
+
+    try:
+        if isinstance(value, (tuple, list)):
+            cimplot.PushStyleVar(variable, _cast_tuple_ImVec2(value))
+        elif isinstance(value, float):
+            cimplot.PushStyleVar(variable, <float>(float(value)))
+        elif isinstance(value, int):
+            cimplot.PushStyleVar(variable, <int>(int(value)))
+    except ValueError:
+        raise ValueError(
+            "Style value must be float, or int or two-elements list/tuple"
+        )
+    else:
+        return True
+
+
+def pop_style_var(int count=1):
+    cimplot.PopStyleVar(count)
+
+
+def set_next_line_style(tuple col = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO):
+    cimplot.SetNextLineStyle(_cast_tuple_ImVec4(col), weight)
+
+
+def set_next_fill_style(tuple col = IMPLOT_AUTO_COL, float alpha_mod = IMPLOT_AUTO):
+    cimplot.SetNextFillStyle(_cast_tuple_ImVec4(col), alpha_mod)
+
+
+def set_next_marker_style(cimplot.ImPlotMarker marker = IMPLOT_AUTO, float size = IMPLOT_AUTO, tuple fill = IMPLOT_AUTO_COL, float weight = IMPLOT_AUTO, tuple outline = IMPLOT_AUTO_COL):
+    cimplot.SetNextMarkerStyle(marker, size, _cast_tuple_ImVec4(fill), weight, _cast_tuple_ImVec4(outline))
+
+
+def set_next_error_bar_style(tuple col = IMPLOT_AUTO_COL, float size = IMPLOT_AUTO, float weight = IMPLOT_AUTO):
+    cimplot.SetNextErrorBarStyle(_cast_tuple_ImVec4(col), size, weight)
+
+
+def push_style_color(
+    cimplot.ImPlotCol variable,
+    float r,
+    float g,
+    float b,
+    float a = 1.
+):
+    if not (0 <= variable < cimplot.ImPlotCol_COUNT):
+        warnings.warn("Unknown style variable: {}".format(variable))
+        return False
+
+    cimplot.PushStyleColor(variable, _cast_args_ImVec4(r, g, b, a))
+    return True
+
+
+def pop_style_color(int count=1):
+    cimplot.PopStyleColor(count)
+
+
+def get_last_item_color():
+    return _cast_ImVec4_tuple(cimplot.GetLastItemColor())
+
+
+def get_style_color_name(int index):
+    cdef const char* c_string = cimplot.GetStyleColorName(index)
+    cdef bytes py_string = c_string
+    return c_string.decode("utf-8")
+
+
+def get_marker_name(int index):
+    cdef const char* c_string = cimplot.GetMarkerName(index)
+    cdef bytes py_string = c_string
+    return c_string.decode("utf-8")
+
+
+def add_colormap(str name, float r, float g, float b, float a, int size, bool qual=True):
+    cdef cimgui.ImVec4 _vec
+    _vec = _cast_args_ImVec4(r, g, b, a)
+    cimplot.AddColormap(_bytes(name), &_vec, size, qual)
+
+
+def get_colormap_count():
+    return cimplot.GetColormapCount()
+
+
+def get_colormap_name(cimplot.ImPlotColormap cmap):
+    cdef const char* c_string = cimplot.GetColormapName(cmap)
+    cdef bytes py_string = c_string
+    return c_string.decode("utf-8")
+
+
+def get_colormap_index(str name):
+    return cimplot.GetColormapIndex(_bytes(name))
+
+
+def push_colormap(cimplot.ImPlotColormap cmap):
+    cimplot.PushColormap(cmap)
+
+
+def push_colormap_name(str name):
+    cimplot.PushColormap(name)
+
+
+def pop_colormap(int count = 1):
+    cimplot.PopColormap(count)
+
+
+def next_colormap_color():
+    return _cast_ImVec4_tuple(cimplot.NextColormapColor())
+
+
+def get_colormap_size(cimplot.ImPlotColormap cmap = IMPLOT_AUTO):
+    return cimplot.GetColormapSize(cmap)
+
+
+def get_colormap_color(int idx, cimplot.ImPlotColormap cmap = IMPLOT_AUTO):
+    return _cast_ImVec4_tuple(cimplot.GetColormapColor(idx, cmap))
+
+
+def sample_colormap(float t, cimplot.ImPlotColormap cmap = IMPLOT_AUTO):
+    return _cast_ImVec4_tuple(cimplot.SampleColormap(t, cmap))
+
+
+def colormap_scale(str label, double scale_min, double scale_max, tuple size = (0,0), cimplot.ImPlotColormap cmap = IMPLOT_AUTO):
+    cimplot.ColormapScale(_bytes(label), scale_min, scale_max, _cast_tuple_ImVec2(size), cmap)
+
+
+def colormap_slider(str label, float t, str format = "", cimplot.ImPlotColormap cmap = IMPLOT_AUTO):
+    cdef float _t = t
+    cdef cimgui.ImVec4 _out
+    _out = _cast_args_ImVec4(0.0, 0.0, 0.0, 0.0)
+    return (
+        cimplot.ColormapSlider(_bytes(label), &_t, &_out, _bytes(format), cmap),
+        _cast_ImVec4_tuple(_out))
+
+
+def colormap_button(str label, tuple size = (0,0), cimplot.ImPlotColormap cmap = IMPLOT_AUTO):
+    return cimplot.ColormapButton(_bytes(label), _cast_tuple_ImVec2(size), cmap)
+
+
+def bust_color_cache(str plot_title_id):
+    cimplot.BustColorCache(_bytes(plot_title_id))
+
+
+def item_icon_idx(value):
+    cimplot.ItemIcon(<cimgui.ImU32>(value))
+
+
+def item_icon_rgba(float r, float g, float b, float a = 1.):
+    cimplot.ItemIcon(_cast_args_ImVec4(r, g, b, a))
+
+
+def colormap_icon(cimplot.ImPlotColormap cmap = IMPLOT_AUTO):
+    return cimplot.ColormapIcon(cmap)
+
+
+def push_plot_clip_rect():
+    cimplot.PushPlotClipRect()
+
+
+def pop_plot_clip_rect():
+    cimplot.PopPlotClipRect()
+
+
+def show_style_selector(str label):
+    return cimplot.ShowStyleSelector(_bytes(label))
+
+
+def show_colormap_selector(str label):
+    return cimplot.ShowColormapSelector(_bytes(label))
+
+
+def show_style_editor(PlotStyle style=None):
+    if style:
+        cimplot.ShowStyleEditor(style._ptr)
+    else:
+        cimplot.ShowStyleEditor()
+
+
+def show_user_guide():
+    cimplot.ShowUserGuide()
+
+
+def show_metrics_window(closable=False):
+    cdef cimplot.bool opened = True
+
+    if closable:
+        cimplot.ShowMetricsWindow(&opened)
+    else:
+        cimplot.ShowMetricsWindow()
+
+    return opened
+
+
+def show_demo_window(closable=False):
+    cdef cimplot.bool opened = True
+
+    if closable:
+        cimplot.ShowDemoWindow(&opened)
+    else:
+        cimplot.ShowDemoWindow()
+
+    return opened

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ else:
 
 def extension_sources(path):
     sources = ["{0}{1}".format(path, '.pyx' if USE_CYTHON else '.cpp')]
-    
+
     if not USE_CYTHON:
         # note: Cython will pick these files automatically but when building
         #       a plain C++ sdist without Cython we need to explicitly mark
@@ -84,6 +84,9 @@ def extension_sources(path):
             'imgui-cpp/imgui_demo.cpp',
             'imgui-cpp/imgui_widgets.cpp',
             'imgui-cpp/imgui_tables.cpp',
+            'implot-cpp/implot.cpp',
+            'implot-cpp/implot_items.cpp',
+            'implot-cpp/implot_demo.cpp',
             'config-cpp/py_imconfig.cpp'
         ]
 
@@ -135,6 +138,16 @@ EXTENSIONS = [
             ('PYIMGUI_CUSTOM_EXCEPTION', None)
         ] + os_specific_macros + general_macros,
         include_dirs=['imgui', 'config-cpp', 'imgui-cpp', 'ansifeed-cpp'],
+    ),
+    Extension(
+        "imgui.plot", extension_sources("imgui/plot"),
+        extra_compile_args=os_specific_flags,
+        define_macros=[
+            # note: for raising custom exceptions directly in ImGui code
+            ('PYIMGUI_CUSTOM_EXCEPTION', None)
+        ] + os_specific_macros + general_macros,
+        # include_dirs=['imgui', 'implot-cpp'],
+        include_dirs=['imgui', 'config-cpp', 'imgui-cpp', 'ansifeed-cpp', 'implot-cpp'],
     ),
 ]
 


### PR DESCRIPTION
I'm just throwing this out here. This is supposed to be cython baed ImPlot (https://github.com/epezent/implot) binding for python. It is based off pyimgui in upgrade/v1.79 branch (v1.82 at this point).

I don't really know where to ask the questions about how to proceed with this; going for `pyimplot` as a separate project or offering it as an inclusion into `pyimgui`. Referencing the first mention of this in https://github.com/swistakm/pyimgui/pull/192#issuecomment-804159670.

![Screenshot_2021-03-23_15-37-28](https://user-images.githubusercontent.com/2725009/112163936-c6938a00-8bed-11eb-904e-74684ed28188.png)


Read on if you are interested..

        **Warning: This is alpha quality code.**

Have a look at the `doc/examples/integrations_glfw3_implot.py` that includes ImPlot
demo. Note that the demo was **NOT** ported to python yet.

It is not clear to me if this is the best place for ImPlot python binding. The
question remains if it would be better to place this code into a separate project,
or provide it as part of pyimgui. As of now the latter has been chosen due to my
laziness, poor undestanding of cython and also due to some obstacles
encountered during the process of creating this binding.

Read on if you are interested in couple of details.

As per ImGui and ImPlot documentation using them both as shared library is not recomended.
In case of python binding this is exactly what is being done. The ImGui part ends up being
a shared library and plot becomes a separate shared library. Creating a single shared library
(with ImGui and ImPlot) does not sound like a good idea at all so lets not go there. Not going
with shared library is also something that we can not do; AFAICT due to the way cypthon does
its business (I might be wrong).

At the level of C++ that cython wraps into python module and functions, ImPlot want access
to `imgui.h` and `imgui_internal.h`. For example ImPlot uses `ImTextureID`, `ImGuiCond`,
`ImGuiMouseButton`, `ImGuiKeyModFlags`, `ImGuiDragDropFlags`, `ImU32`, `ImDrawList`, `ImGuiContext`,
`ImVec2`, `ImVec4` and alike. These need to be exposed a cython level, too. Currently,
these come from `cimgui` and `internal` modules provided by pyimgui binding. Using them is
as simple as adding a `cimport` line to a `cimplot.pxd`. pyimgui (c)imports were requiered for
`plot.pyx` as well:

        cimport cimplot
        cimport cimgui
        cimport core
        cimport enums

If the ImPlot is placed in a separate project/repo these would need to be redefined.


When I tried to compile the ImPlot C++ code for cython binding (without adding ImGui sources)
for that shared library, doing `import imgui` in a user script fails with `GImGui` being undefined.
Have I missed something there during the library build?! I don't know.

If the ImPlot binding is separate from ImGui binding (cleanest approach), I'm not sure how
the user script would behave if pyimgui and pyimplot would be based of different ImGui C++ code.
Might be a non-issue, but I just do not know.

Have any ideas or suggestions on the above topics? Bring them up, please!

